### PR TITLE
Basic Beacon API

### DIFF
--- a/apis/beacon/basic.md
+++ b/apis/beacon/basic.md
@@ -28,14 +28,14 @@ port is not part of the specification.
 
 Table of endpoints:
 
-| Title | HTTP Path |
-| --- | --- |
-[Beacon Head](#beacon-head) | `/beacon/head`
-[Beacon Block](#beacon-block) | `/beacon/block`
-[Beacon State](#beacon-state) | `/beacon/state`
-[Network Peer Id](#network-peerid) | `/network/peer_id`
-[Network Peers](#network-peers) | `/network/peers`
-[Network ENR Address](#network-enr-address) | `/network/enr`
+| Title | HTTP Path | Description |
+| --- | --- | -- |
+[Beacon Head](#beacon-head) | `/beacon/head` | Get the head slot, block root and state root of the canonical chain.
+[Beacon Block](#beacon-block) | `/beacon/block` | Get a `BeaconBlock` by slot or root.
+[Beacon State](#beacon-state) | `/beacon/state` | Get a `BeaconState` by slot or root
+[Network Peer Id](#network-peerid) | `/network/peer_id` | Get a node's libp2p `PeerId`.
+[Network Peers](#network-peers) | `/network/peers` | List a node's libp2p peers (as `PeerIds`).
+[Network ENR Address](#network-enr-address) | `/network/enr` | Get a node's discovery `ENR` address.
 
 ## Beacon Head
 
@@ -65,7 +65,7 @@ Typical Responses | 200
 #### HTTP Example
 
 ```
-$ curl "localhost:5051/node/head"
+$ curl "localhost:5051/beacon/head"
 {"slot":546,"block_root":"0xee0973130905bfdf1deeed88ac0c09623c2cc071b03db68097f2e3b496258c17","state_root":"0xc87889ad8c760b1ec14746271372f9fb53d9f16463dcd224f86a6207799ad702"}
 ```
 
@@ -175,7 +175,7 @@ Typical Responses | 200, 404
 #### HTTP Example
 
 ```
-$ curl localhost:5051/beacon/state?slot=0
+$ curl "localhost:5051/beacon/state?slot=0"
 {"root":"0x3c06d45011320bc5a340811898e27c427547ee79e1e0f29892b4c5235d0c8c8e","beacon_state":{"genesis_time":1566448200,"slot":0,
 ```
 

--- a/apis/beacon/basic.md
+++ b/apis/beacon/basic.md
@@ -1,0 +1,266 @@
+# Beacon Node Basic API
+
+## Introduction
+
+This document provides a list of abstract API definitions, each accompanied by
+a specification of that endpoint when served via HTTP.
+
+Clients may adhere to this specification by:
+
+- Implementing the HTTP specifications exactly (or a implementing a superset).
+- Using their own transport with respect to the abstract definitions (e.g.
+	gRPC, JSON RPC).
+  - Optionally, basing their resource access paths upon the
+	HTTP paths.
+
+### Notes
+
+- The examples use `localhost:5051` purely for example purposes. The HTTP API
+port is not part of the specification.
+- This document seeks to be loosely coupled to the Eth2 spec, reducing the
+	overhead in maintaining this document as the specification progresses.
+  - Eth2 types (e.g., `BeaconBlock`) are loosely defined
+	and their version (e.g., `v0.8.3`) is open to interpretation.
+  - The JSON encoding of these types is analogous to the YAML serialization
+	  format (each endpoint should include a JSON-encoded example).
+
+## Endpoints
+
+Table of endpoints:
+
+| Title | HTTP Path |
+| --- | --- |
+[Beacon Head](#beacon-head) | `/beacon/head`
+[Beacon Block](#beacon-block) | `/beacon/block`
+[Beacon State](#beacon-state) | `/beacon/state`
+[Network Peer Id](#network-peerid) | `/network/peer_id`
+[Network Peers](#network-peers) | `/network/peers`
+[Network ENR Address](#network-enr-address) | `/network/enr`
+
+## Beacon Head
+
+Requests information about the head of the beacon chain, from the node's
+perspective.
+
+#### Example Response
+
+```
+{
+	slot: 1,
+	block_root: "0xe7bb65da065e8ea1f6d5adde378348ed",
+	state_root: "0x981fbdb550d2b5a36370f471fc16ddcf"
+}
+```
+
+### HTTP Specification
+
+| Property | Specification |
+| --- |--- |
+Path | `/beacon/head`
+Method | GET
+JSON Encoding | Object
+Query Parameters | None
+Typical Responses | 200
+
+#### HTTP Example
+
+```
+$ curl "localhost:5051/node/head"
+{"slot":546,"block_root":"0xee0973130905bfdf1deeed88ac0c09623c2cc071b03db68097f2e3b496258c17","state_root":"0xc87889ad8c760b1ec14746271372f9fb53d9f16463dcd224f86a6207799ad702"}
+```
+
+## Beacon Block
+
+Request that the node return a beacon chain block that matches the provided
+criteria (a block `root` or beacon chain `slot`). Only one of the parameters
+should be provided as a criteria.
+
+### Parameters
+
+Accepts one of the following parameters:
+
+#### `slot`: `Slot`
+
+Query by slot number. Any block returned must be in the canonical chain (i.e.,
+either the head or an ancestor of the head).
+
+#### `root`: `Bytes32`
+
+Query by tree hash root. A returned block is not required to be in the
+canonical chain.
+
+### Returns
+
+Returns an object containing a single `BeaconBlock` and it's signed root.
+
+#### Example Response
+
+```
+{
+	root: "0x98e5edb27e53d238a9524590e62b1413",
+	beacon_block: {
+		slot: 42,
+		parent_root: "0xabfb96c38165791636acaf72c4529c0b",
+		...
+	},
+}
+```
+
+### HTTP Specification
+
+| Property | Specification |
+| --- |--- |
+Path | `/beacon/block`
+Method | GET
+JSON Encoding | Object
+Query Parameters | `slot`, `root`
+Typical Responses | 200, 404
+
+#### HTTP Example
+
+```
+$ curl "localhost:5051/beacon/block?slot=0"
+{"root":"0x4eaf79f207428f2b6b6cbee14d4e7d19a114e1f60334905a10c58b10791243b9","beacon_block":{"slot":0,
+```
+
+_Truncated for brevity._
+
+## Beacon State
+
+Request that the node return a beacon chain state that matches the provided
+criteria (a state `root` or beacon chain `slot`). Only one of the parameters
+should be provided as a criteria.
+
+### Parameters
+
+Accepts one of the following parameters:
+
+#### `slot`: `Slot`
+
+Query by slot number. Any state returned must be in the canonical chain (i.e.,
+either the head or an ancestor of the head).
+
+#### `root`: `Bytes32`
+
+Query by tree hash root. A returned state is not required to be in the
+canonical chain.
+
+### Returns
+
+Returns an object containing a single `BeaconState` and it's tree hash root.
+
+#### Example Response
+
+```
+{
+	root: "0x68861c0151d232c75b8dfa24b8a07b65",
+	beacon_state: {
+		genesis_time: 1566444600,
+		slot: 42,
+		...
+	},
+}
+```
+
+### HTTP Specification
+
+| Property | Specification |
+| --- |--- |
+Path | `/beacon/state`
+Method | GET
+JSON Encoding | Object
+Query Parameters | `slot`, `root`
+Typical Responses | 200, 404
+
+#### HTTP Example
+
+```
+$ curl localhost:5051/beacon/state?slot=0
+{"root":"0x3c06d45011320bc5a340811898e27c427547ee79e1e0f29892b4c5235d0c8c8e","beacon_state":{"genesis_time":1566448200,"slot":0,
+```
+
+_Truncated for brevity._
+
+## Network Peer ID
+
+Requests the beacon node's local `PeerId`.
+
+#### Example Response
+
+```
+"QmVFcULBYZecPdCKgGmpEYDqJLqvMecfhJadVBtB371Avd"
+```
+
+### HTTP Specification
+
+| Property | Specification |
+| --- |--- |
+Path | `/network/peer_id`
+Method | GET
+JSON Encoding | String (base58)
+Query Parameters | None
+Typical Responses | 200
+
+#### HTTP Example
+
+```
+$ curl localhost:5051/network/peer_id
+"QmVFcULBYZecPdCKgGmpEYDqJLqvMecfhJadVBtB371Avd"
+```
+
+## Network Peers
+
+Requests the beacon node for one `MultiAddr` for each connected peer.
+
+#### Example Response
+
+```
+[
+	"QmaPGeXcfKFMU13d8VgbnnpeTxcvoFoD9bUpnRGMUJ1L9w",
+	"QmZt47cP8V96MgiS35WzHKpPbKVBMqr1eoBNTLhQPqpP3m"
+]
+```
+
+### HTTP Specification
+
+| Property | Specification |
+| --- |--- |
+Path | `/network/peers`
+Method | GET
+JSON Encoding | [String] (base58)
+Query Parameters | None
+Typical Responses | 200
+
+#### HTTP Example
+
+```
+$ curl localhost:5051/network/peers
+["QmaPGeXcfKFMU13d8VgbnnpeTxcvoFoD9bUpnRGMUJ1L9w","QmZt47cP8V96MgiS35WzHKpPbKVBMqr1eoBNTLhQPqpP3m"]
+```
+
+## Network ENR Address
+
+Requests the beacon node for it's listening `ENR` address.
+
+#### Example Response
+
+```
+-IW4QPYyGkXJSuJ2Eji8b-m4PTNrW4YMdBsNOBrYAdCk8NLMJcddAiQlpcv6G_hdNjiLACOPTkqTBhUjnC0wtIIhyQkEgmlwhKwqAPqDdGNwgiMog3VkcIIjKIlzZWNwMjU2azGhA1sBKo0yCfw4Z_jbggwflNfftjwKACu-a-CoFAQHJnrm
+```
+
+### HTTP Specification
+
+| Property | Specification |
+| --- |--- |
+Path | `/network/enr`
+Method | GET
+JSON Encoding | String (base64)
+Query Parameters | None
+Typical Responses | 200
+
+#### HTTP Example
+
+```
+$ curl localhost:5051/network/enr
+"-IW4QPYyGkXJSuJ2Eji8b-m4PTNrW4YMdBsNOBrYAdCk8NLMJcddAiQlpcv6G_hdNjiLACOPTkqTBhUjnC0wtIIhyQkEgmlwhKwqAPqDdGNwgiMog3VkcIIjKIlzZWNwMjU2azGhA1sBKo0yCfw4Z_jbggwflNfftjwKACu-a-CoFAQHJnrm"
+```


### PR DESCRIPTION
## What

Adds a markdown document describing a basic beacon API that provides block, state, head and network information.

## Why

In the short term, clients need to interoperate and it would be helpful if they implemented standard, human-readable APIs so we don't need to go scrounging through logs to find simple things. Also, so people can build tools that can assess our interoperability foo.

In the long term, it'd be great if clients standardize upon API functionality to help make a unified developer ecosystem. Maybe this document can be the basis for this standardization effort.

## Details

What this is:

- Testing the waters to try and find a good format that is:
  - Easily maintainable (i.e., easy to read and modify the source).
  - Not going to require lots of work whenever the spec data structures change.
  - Well defined enough to allow someone to build a HTTP-wrapper library from it.
  - Not completely HTTP-centric; sets a standard that can be used for other transports (e.g., gRPC).
  - Acknowledges that HTTP seems to be the preferred API among clients.
  - Provides easy, `curl`-able examples.
  - Small enough to go from nothing to something with minimal contention.

What this is not:

- Optimized for data transmission (e.g., if you want the finalized checkpoint you need to download the whole state).
- The full suite of useful API endpoints (e.g., there's no shuffling endpoints).

### Use cases

Using this API, we can perform these tasks:

- `$ curl /network/enr` and copy-paste it into a `--bootnodes` CLI flag on another node.
- `$ curl /network/peer_id` to get the node's libp2p PeerId.
- `$ curl /network/peers` to see if a node is peered with some other node (comparing peer ids).
- Check that some nodes agree on the same chain at some slot using  `/beacon/block?slot=42` and comparing the returned `root` fields.
- Check that two nodes share the same finalized root by using `/beacon/head` to learn the state root at the head of the chain, then use `/beacon/state` to read the finalized checkpoints.

Additionally, I hope this API can be used during network testing/analysis with tools that detect network connectivity (connected peers, etc) and canonical chain info (head, blocks at slots, etc).

### Notes

- This API does not allow for requesting multiple blocks or states. I left it out for simplicity, thinking we can add it later. I could be persuaded to add it now, if it's widely desired.
- This API allows a useful method we've implemented in Lighthouse, where you "bootstrap" a node by pointing it at another node's HTTP interface and download the genesis state and peer connection info.