### PR TITLE
Enable dynamic BN url

### DIFF
--- a/apis/validator/beacon-node-oapi.yaml
+++ b/apis/validator/beacon-node-oapi.yaml
@@ -6,6 +6,14 @@ info:
   license:
     name: "Apache 2.0"
     url: "https://www.apache.org/licenses/LICENSE-2.0.html"
+
+servers:
+  - url: "{server_url}"
+    variables:
+      server_url:
+        description: "Beacon node api url"
+        default: "http://public-mainnet-node.ethereum.org/api"
+
 tags:
   - name: MinimalSet
     description: The minimal set of endpoints to enable a working validator implementation.


### PR DESCRIPTION
This enables users to enter any public BN api url in swagger UI in this repo to get data right here in browser.

![image](https://user-images.githubusercontent.com/8836210/73545584-e1300000-443b-11ea-9636-38e399673535.png)
