### PR TITLE
0.11.1 types

### DIFF
--- a/apis/validator/beacon-node-oapi.yaml
+++ b/apis/validator/beacon-node-oapi.yaml
@@ -11,7 +11,7 @@ servers:
   - url: "{server_url}"
     variables:
       server_url:
-        description: "Beacon node api url"
+        description: "Beacon node API url"
         default: "http://public-mainnet-node.ethereum.org/api"
 
 tags:

--- a/apis/validator/beacon-node-oapi.yaml
+++ b/apis/validator/beacon-node-oapi.yaml
@@ -36,7 +36,7 @@ paths:
         500:
           $ref: '#/components/responses/InternalError'
 
-  /node/genesis_time:
+  /node/genesis:
     get:
       tags:
         - MinimalSet
@@ -48,7 +48,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenesisTime'
+                type: object
+                properties:
+                  genesis_time:
+                    $ref: '#/components/schemas/GenesisTime'
+                  genesis_validators_root:
+                    $ref: '#/components/schemas/Root'
         500:
           $ref: '#/components/responses/InternalError'
 

--- a/types/block.yaml
+++ b/types/block.yaml
@@ -7,6 +7,10 @@ schemas:
         allOf:
           - $ref: "./primitive.yaml#/schemas/Uint64"
           - description: "The slot to which this block corresponds."
+      proposer_index:
+        allOf:
+          - $ref: './primitive.yaml#/schemas/Uint64'
+          - description: "Index of validator in validator registry."
       parent_root:
         allOf:
           - $ref: './primitive.yaml#/schemas/Root'
@@ -18,7 +22,7 @@ schemas:
 
   BeaconBlockBody:
     type: object
-    description: "The [`BeaconBlockBody`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#beaconblockbody) object from the Eth2.0 spec."
+    description: "The [`BeaconBlockBody`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#beaconblockbody) object from the Eth2.0 spec."
     properties:
       randao_reveal:
         allOf:
@@ -53,7 +57,7 @@ schemas:
 
 
   BeaconBlock:
-    description: "The [`BeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#beaconblock) object from the Eth2.0 spec."
+    description: "The [`BeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#beaconblock) object from the Eth2.0 spec."
     allOf:
       - $ref: '#/schemas/BeaconBlockCommon'
       - type: object
@@ -71,7 +75,7 @@ schemas:
         $ref: "./primitive.yaml#/schemas/Signature"
 
   BeaconBlockHeader:
-    description: "The [`BeaconBlockHeader`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#beaconblockheader) object from the Eth2.0 spec."
+    description: "The [`BeaconBlockHeader`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#beaconblockheader) object from the Eth2.0 spec."
     allOf:
       - $ref: '#/schemas/BeaconBlockCommon'
       - type: object
@@ -83,7 +87,7 @@ schemas:
 
   SignedBeaconBlockHeader:
     type: object
-    description: "The [`SignedBeaconBlockHeader`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#signedbeaconblockheader) object envelope from the Eth2.0 spec."
+    description: "The [`SignedBeaconBlockHeader`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#signedbeaconblockheader) object envelope from the Eth2.0 spec."
     properties:
       message:
         $ref: "#/schemas/BeaconBlockHeader"

--- a/types/eth1.yaml
+++ b/types/eth1.yaml
@@ -1,7 +1,7 @@
 schemas:
   Eth1Data:
     type: object
-    description: "The [`Eth1Data`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#eth1data) object from the Eth2.0 spec."
+    description: "The [`Eth1Data`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#eth1data) object from the Eth2.0 spec."
     properties:
       deposit_root:
         allOf:

--- a/types/misc.yaml
+++ b/types/misc.yaml
@@ -1,7 +1,7 @@
 schemas:
   Fork:
     type: object
-    description: "The [`Fork`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#fork) object from the Eth2.0 spec."
+    description: "The [`Fork`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#fork) object from the Eth2.0 spec."
     properties:
       previous_version:
         $ref: "./primitive.yaml#/schemas/ForkVersion"
@@ -11,7 +11,7 @@ schemas:
         $ref: "./primitive.yaml#/schemas/Uint64"
   Checkpoint:
     type: object
-    description: "The [`Checkpoint`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#checkpoint"
+    description: "The [`Checkpoint`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#checkpoint"
     properties:
       epoch:
         $ref: "./primitive.yaml#/schemas/Uint64"

--- a/types/operations/attestation.yaml
+++ b/types/operations/attestation.yaml
@@ -1,7 +1,7 @@
 schemas:
   IndexedAttestation:
     type: object
-    description: "The [`IndexedAttestation`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#indexedattestation) object from the Eth2.0 spec."
+    description: "The [`IndexedAttestation`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#indexedattestation) object from the Eth2.0 spec."
     properties:
       attesting_indices:
         type: array
@@ -18,7 +18,7 @@ schemas:
 
   Attestation:
     type: object
-    description: "The [`Attestation`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#attestation) object from the Eth2.0 spec."
+    description: "The [`Attestation`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#attestation) object from the Eth2.0 spec."
     properties:
       aggregation_bits:
         type: string
@@ -34,7 +34,7 @@ schemas:
 
   PendingAttestation:
     type: object
-    description: "The [`PendingAttestation`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#pendingattestation) object from the Eth2.0 spec."
+    description: "The [`PendingAttestation`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#pendingattestation) object from the Eth2.0 spec."
     properties:
       aggregation_bits:
         type: string
@@ -50,7 +50,7 @@ schemas:
 
   AttestationData:
     type: object
-    description: "The [`AttestationData`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#attestationdata) object from the Eth2.0 spec."
+    description: "The [`AttestationData`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#attestationdata) object from the Eth2.0 spec."
     properties:
       slot:
         $ref: "../primitive.yaml#/schemas/Uint64"

--- a/types/operations/attester_slashing.yaml
+++ b/types/operations/attester_slashing.yaml
@@ -1,7 +1,7 @@
 schemas:
   AttesterSlashing:
     type: object
-    description: "The [`AttesterSlashing`](https://github.com/ethereum/eth2.0-specs/blob/v0.9.2/specs/core/0_beacon-chain.md#attesterslashing) object from the Eth2.0 spec."
+    description: "The [`AttesterSlashing`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/core/0_beacon-chain.md#attesterslashing) object from the Eth2.0 spec."
     properties:
       attestation_1:
         $ref: './attestation.yaml#/schemas/IndexedAttestation'

--- a/types/operations/deposit.yaml
+++ b/types/operations/deposit.yaml
@@ -1,7 +1,7 @@
 schemas:
   Deposit:
     type: object
-    description: "The [`Deposit`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#deposit) object from the Eth2.0 spec."
+    description: "The [`Deposit`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#deposit) object from the Eth2.0 spec."
     properties:
       proof:
         type: array
@@ -15,7 +15,7 @@ schemas:
         $ref: '#schemas/DepositData'
   DepositData:
     type: object
-    description: "The [`DepositData`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#depositdata) object from the Eth2.0 spec."
+    description: "The [`DepositData`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#depositdata) object from the Eth2.0 spec."
     properties:
       pubkey:
         $ref: '../primitive.yaml#/schemas/PublicKey'

--- a/types/operations/proposer_slashing.yaml
+++ b/types/operations/proposer_slashing.yaml
@@ -1,12 +1,8 @@
 schemas:
   ProposerSlashing:
     type: object
-    description: "The [`ProposerSlashing`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#proposerslashing) object from the Eth2.0 spec."
+    description: "The [`ProposerSlashing`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#proposerslashing) object from the Eth2.0 spec."
     properties:
-      proposer_index:
-        allOf:
-          - $ref: "../primitive.yaml#/schemas/Uint64"
-          - description: "The index of the proposer to be slashed."
       signed_header_1:
         $ref: '../block.yaml#/schemas/SignedBeaconBlockHeader'
       signed_header_2:

--- a/types/operations/voluntary_exit.yaml
+++ b/types/operations/voluntary_exit.yaml
@@ -1,7 +1,7 @@
 schemas:
   VoluntaryExit:
     type: object
-    description: "The [`VoluntaryExit`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#voluntaryexit) object from the Eth2.0 spec."
+    description: "The [`VoluntaryExit`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#voluntaryexit) object from the Eth2.0 spec."
     properties:
       epoch:
         allOf:
@@ -14,7 +14,7 @@ schemas:
 
   SignedVoluntaryExit:
     type: object
-    description: "The [`SignedVoluntaryExit`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#signedvoluntaryexit) object from the Eth2.0 spec."
+    description: "The [`SignedVoluntaryExit`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#signedvoluntaryexit) object from the Eth2.0 spec."
     properties:
       message:
         $ref: "#/schemas/VoluntaryExit"

--- a/types/state.yaml
+++ b/types/state.yaml
@@ -1,10 +1,12 @@
 schemas:
   BeaconState:
     type: object
-    description: "The [`BeaconState`](https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#beaconblock) object from the Eth2.0 spec."
+    description: "The [`BeaconState`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#beaconblock) object from the Eth2.0 spec."
     properties:
       genesis_time:
         $ref: "./primitive.yaml#/schemas/Uint64"
+      genesis_validators_root:
+        $ref: "./primitive.yaml#/schemas/Root"
       slot:
         $ref: "./primitive.yaml#/schemas/Uint64"
       fork:

--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -53,11 +53,6 @@ schemas:
         allOf:
           - $ref: "./primitive.yaml#/schemas/Uint64"
           - description: "The committee index"
-      block_proposal_slot:
-        allOf:
-          - $ref: "./primitive.yaml#/schemas/Uint64"
-          - nullable: true
-          - description: "The slot in which a validator must propose a block, or `null` if block production is not required."
 
   AggregateAndProof:
     allOf:

--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -6,7 +6,7 @@ schemas:
         allOf:
           - $ref: './primitive.yaml#/schemas/Uint64'
           - description: "Index of validator in validator registry."
-      validator_pubkey:
+      pubkey:
         $ref: './primitive.yaml#/schemas/PublicKey'
       withdrawal_credentials:
         allOf:


### PR DESCRIPTION
Notable changes:
- genesis endpoint returns "genesis_validator_root" so validator can construct domains for signatures
- removed "block_proposal_slot" from `AttesterDuty` (not sure how that was forgot there)