### PR TITLE
Fix Uint64 example

### DIFF
--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -26,7 +26,7 @@ schemas:
 
   Uint64:
     type: string
-    example: "18446744073709551615"
+    example: "1"
 
   Root:
     type: string

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -26,7 +26,7 @@ schemas:
 
   Uint64:
     type: string
-    example: "1213123123123123123123123122"
+    example: "18446744073709551615"
 
   Root:
     type: string


### PR DESCRIPTION
The maximum value for uint64 is « 2^64–1 = 18446744073709551615 », previous example was not correct.