### PR TITLE
Use a consistent operationId for /node/health

### DIFF
--- a/apis/node/health.yaml
+++ b/apis/node/health.yaml
@@ -1,5 +1,5 @@
 get:
-  operationId: health
+  operationId: getHealth
   tags:
     - Node
   summary: Get health check


### PR DESCRIPTION
All of the operations in the `/node/*` group prepend the HTTP method type used in their operation ID, except for `/node/health`. This makes the `/node/health` operationId consistent with the others.