### PR TITLE
Remove genesis_fork_version from getGenesis

### DIFF
--- a/apis/beacon/genesis.yaml
+++ b/apis/beacon/genesis.yaml
@@ -20,8 +20,6 @@
                       $ref: '../../beacon-node-oapi.yaml#/components/schemas/GenesisTime'
                     genesis_validators_root:
                       $ref: '../../beacon-node-oapi.yaml#/components/schemas/Root'
-                    genesis_fork_version:
-                      $ref: '../../beacon-node-oapi.yaml#/components/schemas/ForkVersion'
       "404":
         description: "Chain genesis info is not yet known"
       "500":


### PR DESCRIPTION
The genesis fork version is not part of a state, so keeping it around would require keeping an archive / registry of fork ancient fork versions even though in theory, a client can start from an arbitrary (trusted) state. 

Publishing the current and previous fork versions could provide some information here.