### PR TITLE
Remove optionals byte / bytes / hex format

### DIFF
--- a/types/attestation.yaml
+++ b/types/attestation.yaml
@@ -22,7 +22,6 @@ schemas:
     properties:
       aggregation_bits:
         type: string
-        format: byte
         pattern: "^0x[a-fA-F0-9]+$"
         description: "Attester aggregation bits."
       signature:
@@ -38,7 +37,6 @@ schemas:
     properties:
       aggregation_bits:
         type: string
-        format: byte
         pattern: "^0x[a-fA-F0-9]+$"
         description: "Attester aggregation bits."
       data:

--- a/types/block.yaml
+++ b/types/block.yaml
@@ -32,7 +32,6 @@ schemas:
         $ref: './eth1.yaml#/schemas/Eth1Data'
       graffiti:
         type: string
-        format: byte
         pattern: "^0x[a-fA-F0-9]{64}$"
       proposer_slashings:
         type: array

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -31,17 +31,14 @@ schemas:
 
   Root:
     type: string
-    format: hex
     example: "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
     pattern: "^0x[a-fA-F0-9]{64}$"
 
   Hex:
     type: string
-    format: hex
     pattern: "^0x[a-fA-F0-9]{2,}$"
 
   Signature:
     type: string
-    format: bytes
     pattern: "^0x[a-fA-F0-9]{192}$"
     example: "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"

--- a/types/state.yaml
+++ b/types/state.yaml
@@ -82,7 +82,6 @@ BeaconState:
           - $ref: './attestation.yaml#/schemas/PendingAttestation'
     justification_bits:
       type: string
-      format: byte
       pattern: "^0x[a-fA-F0-9]+$"
       description: "Bit set for every recent justified epoch"
     previous_justified_checkpoint:


### PR DESCRIPTION
Remove all optional format specification for string because:
 - Non-ambiguous hex format with length and prefix is already specified in the pattern.
 - Bytes ties to base64 encoding instead of hex as per the Open Api Spec.
 - Byte is a custom format.

Close #49 