### PR TITLE
Add root field to /beacon/headers/{block_id}

### DIFF
--- a/apis/beacon/blocks/header.yaml
+++ b/apis/beacon/blocks/header.yaml
@@ -20,6 +20,8 @@ get:
               data:
                 type: object
                 properties:
+                  root:
+                    $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Root"
                   canonical:
                     type: boolean
                   header:


### PR DESCRIPTION
I noticed this field is missing in `beacon/headers/{block_id}` but present in `beacon/headers`. I assume it's supposed to be in both places, please correct me if I'm wrong :)