### PR TITLE
Add `validator_index` to `...duties/attester...`

### DIFF
--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -37,6 +37,10 @@ AttesterDuty:
   properties:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'
+    validator_index:
+      allOf:
+        - $ref: "./primitive.yaml#/Uint64"
+        - description: "Index of validator in validator registry"
     committee_index:
       allOf:
         - $ref: "./primitive.yaml#/Uint64"


### PR DESCRIPTION
This PR adds the `validator_index` field to the response of `GET /eth​/v1​/validator​/duties​/attester​/{epoch}`.

When consuming this API (writing tests) I noticed that consumers query via `validator_index`, but don't get it back in the response. 

Without the `validator_index` field in the response, consumers must maintain a mapping of `pubkey -> validator_index` on-hand if they wish to match the response to their request.