### PR TITLE
make ENR nullable in peers response

### DIFF
--- a/types/p2p.yaml
+++ b/types/p2p.yaml
@@ -39,7 +39,9 @@
       peer_id:
         $ref: "./p2p.yaml#/PeerId"
       enr:
-        $ref: "./p2p.yaml#/ENR"
+        allOf:
+          - $ref: "./p2p.yaml#/ENR"
+          - nullable: true
       address:
         $ref: "./p2p.yaml#/Multiaddr"
       state:
@@ -58,7 +60,6 @@
 
   ENR:
     type: string
-    nullable: true
     description: "Ethereum node record. [Read more](https://eips.ethereum.org/EIPS/eip-778)"
     example: "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8"
 

--- a/types/p2p.yaml
+++ b/types/p2p.yaml
@@ -58,6 +58,7 @@
 
   ENR:
     type: string
+    nullable: true
     description: "Ethereum node record. [Read more](https://eips.ethereum.org/EIPS/eip-778)"
     example: "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8"
 


### PR DESCRIPTION
in line with a discussion on discord, Teku is not currently able to supply the ENR for peers, because libp2p is kept quite separate from discovery.

There's still a lot of helpful context in the peers list without ENR, so making ENR nullable will keep everything 'correct'.