### PR TITLE
Add committees_at_slot

### DIFF
--- a/apis/validator/beacon_committee_subscriptions.yaml
+++ b/apis/validator/beacon_committee_subscriptions.yaml
@@ -23,8 +23,9 @@ post:
               committee_index:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
               committees_at_slot:
-                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                description: "Number of committees at the returned slot"
+                allOf:
+                  - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+                  - description: "Number of committees at the returned slot"
               slot:
                 allOf:
                   - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'

--- a/apis/validator/beacon_committee_subscriptions.yaml
+++ b/apis/validator/beacon_committee_subscriptions.yaml
@@ -22,6 +22,9 @@ post:
             properties:
               committee_index:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+              committees_at_slot:
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+                description: "Number of committees at the returned slot"
               slot:
                 allOf:
                   - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'

--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -49,6 +49,10 @@ AttesterDuty:
       allOf:
         - $ref: "./primitive.yaml#/Uint64"
         - description: "Number of validators in committee"
+    committees_at_slot:
+      allOf:
+        - $ref: "./primitive.yaml#/Uint64"
+        - description: "Number of committees at the provided slot"
     validator_committee_index:
       allOf:
         - $ref: "./primitive.yaml#/Uint64"


### PR DESCRIPTION
Here I've added `committees_at_slot` which corresponds to the function parameter with the same name in [compute_subnet_for_attestation](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/validator.md#broadcast-attestation).

The `committees_at_slot` value is is the count of committee indices for attestation a given slot. It is derived purely from the active validator count and some constants.

## Why add the `committees_at_slot` field?

The `committees_at_slot` is a piece of information that:

1. Is trivial for the BN to compute during `/eth/v1/validator/duties/attester/{epoch}`.
1. Is required during edge-cases in `/eth/v1/validator/beacon_committee_subscriptions` and is *not* trivial to compute then.

Both (1) and (2) require access to the shuffling. We already must load the shuffling to serve (1) but this is not true for (2).

Below is an example edge-case where you must call `per_slot_processing` in (1) and then once again during (2).

## Example edge-case

Recall that [`get_committee_count_per_slot`](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#get_committee_count_per_slot) is a function which statically maps the count of active validators against some constants. The `committee_count_per_slot` value changes fairly slowly, it's 4 with 16k validators and next increases at ~21k validators

For the example, let's assume:

- Our head block slot is 31 and our wall-clock slot is 65.
    - *I.e., our head epoch is two behind our wall-clock.*
- In the transition from epoch 0 to 2, we will (magically) go from having 4 committees per slot to 5 committees.

Now, at this point in time, we receive the following subscription on `/eth/v1/validator/beacon_committee_subscriptions`:

```json
[
  {
    "committee_index": "1",
    "slot": "65",
    "is_aggregator": true
  }
]
```

Now, in order to compute the subnet we will subscribe to, we must run [compute_subnet_for_attestation](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/validator.md#broadcast-attestation). Importantly, one of the inputs to this function is `committees_per_slot` which is `5` in slot 65 (the slot of the request). If we call it with the value of our current head (slot 31),  `committees_per_slot` will be `4` and the output of the function will be different. Because of this, we *must* call `per_slot_processing` on our head state to transition it from epoch 0 to epoch 1 and learn active validator count (and therefore `committees_per_slot`) in that epoch.

## Summary

In the example I've shown a scenario that, whilst contrived for demonstration is equivalently feasible in mainnet, where the BN is faulty unless it performs performs some "heavy-lifting" (state copy and `per_slot_processing`) in order to process a `/eth/v1/validator/beacon_committee_subscriptions` request.

The only reason for the heavy lifting is to learn the `committees_per_slot` value.

The `committees_per_slot` value is already known during the call to the attester duties endpoint, a call which we expect to precede a call to the subscriptions endpoint.

Given these points, I find it worthwhile to add the `committees_per_slot` value to the attester duties response.