### PR TITLE
Add validator balances endpoint

### DIFF
--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -43,7 +43,7 @@ get:
               data:
                 type: array
                 items:
-                  $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorBalancesResponse'
+                  $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorBalanceResponse'
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
 

--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -19,17 +19,6 @@ get:
         items:
           description: "Either hex encoded public key (with 0x prefix) or validator index"
           type: string
-    - name: status
-      description: "[Validator status specification](https://hackmd.io/ofFJ5gOmQpu1jjHilHbdQQ)"
-      in: query
-      required: false
-      schema:
-        type: array
-        uniqueItems: true
-        items:
-          allOf:
-            - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorStatus'
-            - enum: ["active", "pending", "exited", "withdrawal"]
 
   responses:
     "200":

--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -1,0 +1,49 @@
+get:
+  operationId: "getStateValidatorBalances"
+  summary: "Get validator balances from state"
+  description: "Returns filterable list of validator balances."
+  tags:
+    - Beacon
+  parameters:
+    - name: state_id
+      in: path
+      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
+    - name: id
+      description: "Either hex encoded public key (with 0x prefix) or validator index"
+      in: query
+      required: false
+      schema:
+        type: array
+        maxItems: 30
+        uniqueItems: true
+        items:
+          description: "Either hex encoded public key (with 0x prefix) or validator index"
+          type: string
+    - name: status
+      description: "[Validator status specification](https://hackmd.io/ofFJ5gOmQpu1jjHilHbdQQ)"
+      in: query
+      required: false
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          allOf:
+            - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorStatus'
+            - enum: ["active", "pending", "exited", "withdrawal"]
+
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            title: GetStateValidatorBalancesResponse
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorBalancesResponse'
+    "500":
+      $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
+

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -48,10 +48,10 @@ paths:
     $ref: "./apis/beacon/states/finality_checkpoints.yaml"
   /eth/v1/beacon/states/{state_id}/validators:
     $ref: "./apis/beacon/states/validators.yaml"
-  /eth/v1/beacon/states/{state_id}/validator_balances:
-    $ref: "./apis/beacon/states/validator_balances.yaml"
   /eth/v1/beacon/states/{state_id}/validators/{validator_id}:
     $ref: "./apis/beacon/states/validator.yaml"
+  /eth/v1/beacon/states/{state_id}/validator_balances:
+    $ref: "./apis/beacon/states/validator_balances.yaml"
   /eth/v1/beacon/states/{state_id}/committees/{epoch}:
     $ref: "./apis/beacon/states/committee.yaml"
   /eth/v1/beacon/headers:
@@ -132,8 +132,8 @@ components:
       $ref: './types/block.yaml#/SignedBeaconBlockHeader'
     ValidatorResponse:
       $ref: './types/api.yaml#/ValidatorResponse'
-    ValidatorBalancesResponse:
-      $ref: './types/api.yaml#/ValidatorBalancesResponse'
+    ValidatorBalanceResponse:
+      $ref: './types/api.yaml#/ValidatorBalanceResponse'
     ValidatorStatus:
       $ref: './types/api.yaml#/ValidatorStatus'
     Committee:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -48,6 +48,8 @@ paths:
     $ref: "./apis/beacon/states/finality_checkpoints.yaml"
   /eth/v1/beacon/states/{state_id}/validators:
     $ref: "./apis/beacon/states/validators.yaml"
+  /eth/v1/beacon/states/{state_id}/validator_balances:
+    $ref: "./apis/beacon/states/validator_balances.yaml"
   /eth/v1/beacon/states/{state_id}/validators/{validator_id}:
     $ref: "./apis/beacon/states/validator.yaml"
   /eth/v1/beacon/states/{state_id}/committees/{epoch}:
@@ -130,6 +132,8 @@ components:
       $ref: './types/block.yaml#/SignedBeaconBlockHeader'
     ValidatorResponse:
       $ref: './types/api.yaml#/ValidatorResponse'
+    ValidatorBalancesResponse:
+      $ref: './types/api.yaml#/ValidatorBalancesResponse'
     ValidatorStatus:
       $ref: './types/api.yaml#/ValidatorStatus'
     Committee:

--- a/types/api.yaml
+++ b/types/api.yaml
@@ -16,7 +16,7 @@ ValidatorResponse:
     validator:
       $ref: "./validator.yaml#/Validator"
 
-ValidatorBalancesResponse:
+ValidatorBalanceResponse:
   type: object
   properties:
     index:
@@ -27,10 +27,6 @@ ValidatorBalancesResponse:
       allOf:
         - $ref: "./primitive.yaml#/Gwei"
         - description: "Current validator balance in gwei."
-    effective_balance:
-      allOf:
-        - $ref: "./primitive.yaml#/Gwei"
-        - description: "Current validator effective balance in gwei."
 
 ValidatorStatus:
   description: |

--- a/types/api.yaml
+++ b/types/api.yaml
@@ -16,6 +16,21 @@ ValidatorResponse:
     validator:
       $ref: "./validator.yaml#/Validator"
 
+ValidatorBalancesResponse:
+  type: object
+  properties:
+    index:
+      allOf:
+        - $ref: './primitive.yaml#/Uint64'
+        - description: "Index of validator in validator registry."
+    balance:
+      allOf:
+        - $ref: "./primitive.yaml#/Gwei"
+        - description: "Current validator balance in gwei."
+    effective_balance:
+      allOf:
+        - $ref: "./primitive.yaml#/Gwei"
+        - description: "Current validator effective balance in gwei."
 
 ValidatorStatus:
   description: |


### PR DESCRIPTION
This patch adds the validator balances endpoint `/eth/v1/beacon/states/{state_id}/validator_balances`  Its purpose is to fetch validator balance at a given epoch separate from the entire validator structure.

Rationale behind this being a separate endpoint is that historical data on a validator is, in general, not a lot of use; the current state for validators provides all of the prior state of interest for most use cases.  Having to fetch or recreate the entire validator structure for multiple epochs, when all a user wants is to obtain a history of their balance, can lead to a lot of wasted CPU time (at least it does with the current non-standard APIs on beacon node implementations).