### PR TITLE
Change BeaconBlockBody to use SignedVoluntaryExit

### DIFF
--- a/types/block.yaml
+++ b/types/block.yaml
@@ -51,7 +51,7 @@ BeaconBlockBody:
     voluntary_exits:
       type: array
       items:
-        $ref: './voluntary_exit.yaml#/VoluntaryExit'
+        $ref: './voluntary_exit.yaml#/SignedVoluntaryExit'
 
 
 BeaconBlock:


### PR DESCRIPTION
This PR changes the `BeaconBlockBody` schema to use a `SignedVolnutaryExit` instead of a `VoluntaryExit` as all elements in a block should be signed.