### PR TITLE
Change validator.slashed to validator.slashed_epoch

### DIFF
--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -11,10 +11,10 @@ Validator:
       allOf:
         - $ref: "./primitive.yaml#/Gwei"
         - description: "Balance at stake in Gwei."
-    slashed:
-      type: boolean
-      example: false
-      description: "Was validator slashed (not longer active)."
+    slashed_epoch:
+      allOf:
+        - $ref: "./primitive.yaml#/Uint64"
+        - description: "Epoch when validator was slashed. 'FAR_FUTURE_EPOCH' if not slashed."
     activation_eligibility_epoch:
       allOf:
         - $ref: "./primitive.yaml#/Uint64"


### PR DESCRIPTION
Currently there is `GetStateValidatorResponse.data.status` which indicates if a validator is slashed or not and also there is `GetStateValidatorResponse.data.validator.slashed` which is redundant information.

I think it is better to use `GetStateValidatorResponse.data.validator.slashed_epoch` just like `GetStateValidatorResponse.data.validator.{exit,withdrawable,activation,activation_eligibility}_epoch`.