### PR TITLE
Add validator index to proposer duties.

### DIFF
--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -63,6 +63,10 @@ ProposerDuty:
   properties:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'
+    validator_index:
+      allOf:
+        - $ref: "./primitive.yaml#/Uint64"
+        - description: "Index of validator in validator registry."
     slot:
       allOf:
         - $ref: "./primitive.yaml#/Uint64"


### PR DESCRIPTION
This adds the validator index to proposer duty return information, so that similar to attester duties they can be referenced by index rather than public key if desired.