### PR TITLE
Add return code 400 for malformed input

### DIFF
--- a/apis/beacon/blocks/attestations.yaml
+++ b/apis/beacon/blocks/attestations.yaml
@@ -28,7 +28,7 @@ get:
         application/json:
           schema:
             allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
               - example:
                   code: 400
                   message: "Invalid block ID: current"

--- a/apis/beacon/blocks/attestations.yaml
+++ b/apis/beacon/blocks/attestations.yaml
@@ -22,6 +22,16 @@ get:
                 type: array
                 items:
                   $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Attestation'
+    "400":
+      description: "The block ID supplied could not be parsed"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - example:
+                  code: 400
+                  message: "Invalid block ID: current"
     "404":
       description: "Block not found"
       content:

--- a/apis/beacon/blocks/block.yaml
+++ b/apis/beacon/blocks/block.yaml
@@ -25,7 +25,7 @@ get:
         application/json:
           schema:
             allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
               - example:
                   code: 400
                   message: "Invalid block ID: current"

--- a/apis/beacon/blocks/block.yaml
+++ b/apis/beacon/blocks/block.yaml
@@ -19,6 +19,16 @@ get:
             properties:
               data:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock"
+    "400":
+      description: "The block ID supplied could not be parsed"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - example:
+                  code: 400
+                  message: "Invalid block ID: current"
     "404":
       description: "Block not found"
       content:

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -18,7 +18,15 @@ post:
     "202":
       description: "The block failed validation, but was successfully broadcast anyway. It was not integrated into the beacon node's database."
     "400":
-      $ref: '../../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
+      description: "The `SignedBeaconBlock` object is invalid"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - example:
+                  code: 400
+                  message: "Invalid block: missing signature"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
     "503":

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -23,7 +23,7 @@ post:
         application/json:
           schema:
             allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
               - example:
                   code: 400
                   message: "Invalid block: missing signature"

--- a/apis/beacon/blocks/header.yaml
+++ b/apis/beacon/blocks/header.yaml
@@ -26,6 +26,16 @@ get:
                     type: boolean
                   header:
                     $ref: "../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlockHeader"
+    "400":
+      description: "The block ID supplied could not be parsed"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - example:
+                  code: 400
+                  message: "Invalid block ID: current"
     "404":
       description: "Block not found"
       content:

--- a/apis/beacon/blocks/header.yaml
+++ b/apis/beacon/blocks/header.yaml
@@ -32,7 +32,7 @@ get:
         application/json:
           schema:
             allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
               - example:
                   code: 400
                   message: "Invalid block ID: current"

--- a/apis/beacon/blocks/headers.yaml
+++ b/apis/beacon/blocks/headers.yaml
@@ -40,5 +40,15 @@ get:
                       type: boolean
                     header:
                       $ref: "../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlockHeader"
+    "400":
+      description: "The slot or parent root supplied could not be parsed"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - example:
+                  code: 400
+                  message: "Invalid slot: current"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/blocks/headers.yaml
+++ b/apis/beacon/blocks/headers.yaml
@@ -41,14 +41,14 @@ get:
                     header:
                       $ref: "../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlockHeader"
     "400":
-      description: "The slot or parent root supplied could not be parsed"
+      description: "The block ID supplied could not be parsed"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
               - example:
                   code: 400
-                  message: "Invalid slot: current"
+                  message: "Invalid block ID: current"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/blocks/root.yaml
+++ b/apis/beacon/blocks/root.yaml
@@ -30,7 +30,7 @@ get:
         application/json:
           schema:
             allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
               - example:
                   code: 400
                   message: "Invalid block ID: current"

--- a/apis/beacon/blocks/root.yaml
+++ b/apis/beacon/blocks/root.yaml
@@ -24,6 +24,16 @@ get:
                     allOf:
                       - description: HashTreeRoot of BeaconBlock/BeaconBlockHeader object
                       - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Root'
+    "400":
+      description: "The block ID supplied could not be parsed"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - example:
+                  code: 400
+                  message: "Invalid block ID: current"
     "404":
       description: "Block not found"
       content:

--- a/apis/beacon/pool/attestations.yaml
+++ b/apis/beacon/pool/attestations.yaml
@@ -34,7 +34,7 @@ get:
         application/json:
           schema:
             allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
               - example:
                   code: 400
                   message: "Invalid slot: current"

--- a/apis/beacon/pool/attestations.yaml
+++ b/apis/beacon/pool/attestations.yaml
@@ -28,6 +28,16 @@ get:
                 type: array
                 items:
                   $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Attestation'
+    "400":
+      description: "The slot or committee index could not be parsed"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - example:
+                  code: 400
+                  message: "Invalid slot: current"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
 

--- a/apis/beacon/states/committee.yaml
+++ b/apis/beacon/states/committee.yaml
@@ -48,7 +48,7 @@ get:
                 items:
                   $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Committee'
     "400":
-      description: "Slot doesn't belong in epoch"
+      description: "Invalid state ID, index, epoch, slot, or combination thereof"
       content:
         application/json:
           schema:
@@ -56,7 +56,7 @@ get:
               - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
               - example:
                   code: 400
-                  message: "Slot doesn't belong in epoch"
+                  message: "Slot does not belong in epoch"
     "404":
       description: "State not found"
       content:

--- a/apis/beacon/states/finality_checkpoints.yaml
+++ b/apis/beacon/states/finality_checkpoints.yaml
@@ -28,6 +28,16 @@ get:
                     $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Checkpoint'
                   finalized:
                     $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Checkpoint'
+    "400":
+      description: "Invalid state ID"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Invalid state ID: current"
     "404":
       description: "State not found"
       content:

--- a/apis/beacon/states/fork.yaml
+++ b/apis/beacon/states/fork.yaml
@@ -21,6 +21,16 @@ get:
               data:
                 $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Fork'
 
+    "400":
+      description: "Invalid state ID"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Invalid state ID: current"
     "404":
       description: "State not found"
       content:

--- a/apis/beacon/states/root.yaml
+++ b/apis/beacon/states/root.yaml
@@ -24,6 +24,16 @@ get:
                     allOf:
                       - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Root'
                       - description: HashTreeRoot of BeaconState object
+    "400":
+      description: "Invalid state ID"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Invalid state ID: current"
     "404":
       description: "State not found"
       content:

--- a/apis/beacon/states/validator.yaml
+++ b/apis/beacon/states/validator.yaml
@@ -27,7 +27,16 @@ get:
             properties:
               data:
                 $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorResponse'
-
+    "400":
+      description: "Invalid state or validator ID"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Invalid state ID: current"
     "404":
       description: "Not Found"
       content:

--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -33,6 +33,16 @@ get:
                 type: array
                 items:
                   $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorBalanceResponse'
+    "400":
+      description: "Invalid state or validator ID"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Invalid state ID: current"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
 

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -44,6 +44,16 @@ get:
                 type: array
                 items:
                   $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorResponse'
+    "400":
+      description: "Invalid state or validator ID, or status"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Invalid state ID: current"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
 

--- a/apis/debug/state.yaml
+++ b/apis/debug/state.yaml
@@ -19,7 +19,16 @@ get:
             properties:
               data:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/BeaconState'
-
+    "400":
+      description: "Invalid state ID"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Invalid state ID: current"
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
 

--- a/apis/debug/state.yaml
+++ b/apis/debug/state.yaml
@@ -25,7 +25,7 @@ get:
         application/json:
           schema:
             allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
               - example:
                   code: 400
                   message: "Invalid state ID: current"

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -75,7 +75,7 @@ get:
         application/json:
           schema:
             allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - $ref: "../../../beacon-node-oapi.yaml#/components/responses/InvalidRequest"
               - example:
                   code: 400
                   message: "Invalid topic: weather_forecast"

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -75,7 +75,7 @@ get:
         application/json:
           schema:
             allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/responses/InvalidRequest"
+              - $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
               - example:
                   code: 400
                   message: "Invalid topic: weather_forecast"

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -69,6 +69,16 @@ get:
                 event: chain_reorg\n
                 data: "{\"slot\":\"200\", \"depth\": \"50\", \"old_head_block\": \"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf\", \"new_head_block\": \"0x76262e91970d375a19bfe8a867288d7b9cde43c8635f598d93d39d041706fc76\", \"old_head_state\":\"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf\", \"new_state_head\": \"0x600e852a08c1200654ddf11025f1ceacb3c2e74bdd5c630cde0838b2591b69f9\", \"epoch\": \"2\" }"\n
                 \n
+    "400":
+      description: "The topics supplied could not be parsed"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - example:
+                  code: 400
+                  message: "Invalid topic: weather_forecast"
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
       

--- a/apis/node/peer.yaml
+++ b/apis/node/peer.yaml
@@ -27,7 +27,7 @@ get:
         application/json:
           schema:
             allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
               - example:
                   code: 400
                   message: "Invalid peer ID: localhost"

--- a/apis/node/peer.yaml
+++ b/apis/node/peer.yaml
@@ -27,7 +27,7 @@ get:
         application/json:
           schema:
             allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
               - example:
                   code: 400
                   message: "Invalid peer ID: localhost"

--- a/apis/node/peer.yaml
+++ b/apis/node/peer.yaml
@@ -21,6 +21,16 @@ get:
             properties:
               data:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Peer'
+    "400":
+      description: "The peer ID supplied could not be parsed"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/InvalidRequest"
+              - example:
+                  code: 400
+                  message: "Invalid peer ID: localhost"
     "404":
       description: "Peer not found"
       content:

--- a/apis/validator/duties/attester.yaml
+++ b/apis/validator/duties/attester.yaml
@@ -41,16 +41,15 @@ get:
                 items:
                   $ref: '../../../beacon-node-oapi.yaml#/components/schemas/AttesterDuty'
     "400":
-      description: "Invalid request"
+      description: "Invalid epoch or index"
       content:
         application/json:
           schema:
-            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-          examples:
-            InvalidEpoch:
-              value:
-                code: 400
-                message: Cannot get attester duties for X epoch ahead
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Invalid epoch: -2"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
     "503":

--- a/apis/validator/duties/proposer.yaml
+++ b/apis/validator/duties/proposer.yaml
@@ -25,16 +25,15 @@ get:
                 items:
                   $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ProposerDuty"
     "400":
-      description: Invalid request
+      description: "Invalid epoch"
       content:
         application/json:
           schema:
-            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-          examples:
-            InvalidEpoch:
-              value:
-                code: 400
-                message: Cannot get attester duties for X epoch ahead
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Invalid epoch: -2"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
     "503":


### PR DESCRIPTION
This adds a response code 400 for all endpoints that have an input.  It allows it to be returned when the input data is in some way malformed.

Note that there is a difference between this and 404.  If you asked for block 5 and block 5 doesn't exist you would expect a 404.  If you asked for block foo you would expect a 400, as 'foo' is not a valid block number.