### PR TITLE
Add eventstream to the ValidatorRequiredApi list.

### DIFF
--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -3,6 +3,7 @@ get:
   summary: Subscribe to beacon node events
   tags:
     - Events
+    - ValidatorRequiredApi
   description: |
     Provides endpoint to subscribe to beacon node Server-Sent-Events stream.
     Consumers should use [eventsource](https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface)


### PR DESCRIPTION
Add the eventstream endpoint to the list of validatorRequiredApi endpoints.

Without this endpoint, the validator client won't see re-orgs, and won't know duties need to be fetched again, so I'm fairly sure it belongs in the required set.