### PR TITLE
Add minimal tag to spec endpoint.

### DIFF
--- a/apis/config/spec.yaml
+++ b/apis/config/spec.yaml
@@ -2,14 +2,15 @@ get:
   operationId: getSpec
   summary: Get spec params.
   description: |
-    Retrieve specification configuration (without Phase 1 params) used on this node.
-    [Specification params list](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/mainnet.yaml)
+    Retrieve specification configuration used on this node.
+    [Specification params list](https://github.com/ethereum/eth2.0-specs/blob/v1.0.0-rc.0/configs/mainnet/phase0.yaml)
 
     Values are returned with following format:
       - any value starting with 0x in the spec is returned as a hex string
-      - all other values are returned as number
+      - numeric values are returned as a quoted integer
   tags:
     - Config
+    - ValidatorRequiredApi
   responses:
     "200":
       description: Success
@@ -21,10 +22,10 @@ get:
             properties:
               data:
                 description: |
-                  Key value mapping of Phase 0[spec variables](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/mainnet.yaml).
+                  Key value mapping of [spec variables](https://github.com/ethereum/eth2.0-specs/blob/v1.0.0-rc.0/configs/mainnet/phase0.yaml).
                   Values are returned with following format:
                     - any value starting with 0x in the spec is returned as a hex string
-                    - all other values are returned as number
+                    - numeric values are returned as a quoted integer
                 type: object
     "500":
       $ref: ../../beacon-node-oapi.yaml#/components/responses/InternalError


### PR DESCRIPTION
This PR adds the minimal validator tag to the spec endpoint.  This tag is required so that validator clients can fetch required configuration parameters (domains, times, _etc._).

It also fixes the link to the configuration in the specs repository, and clarifies that numbers should be quoted.