### PR TITLE
Move attestation submission to array.

### DIFF
--- a/apis/beacon/pool/attestations.yaml
+++ b/apis/beacon/pool/attestations.yaml
@@ -44,7 +44,12 @@ get:
 post:
   operationId: submitPoolAttestations
   summary: Submit Attestation objects to node
-  description: Submits Attestation objects to node. If attestations pass all validation constraints, node MUST publish attestations on appropriate subnet.
+  description: |
+    Submits Attestation objects to the node.  Each attestation in the request body is processed individually.
+    
+    If an attestation is validated successfully the node MUST publish that attestation on the appropriate subnet.
+
+    If one or more attestations fail validation the node MUST return a 400 error with details of which attestations have failed, and why.
   tags:
     - Beacon
     - ValidatorRequiredApi
@@ -60,14 +65,10 @@ post:
     "200":
       description: Attestations are stored in pool and broadcast on appropriate subnet
     "400":
-      description: "Invalid attestation"
+      description: "Errors with one or more attestations"
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-              - example:
-                  code: 400
-                  message: "Invalid attestation, it will never pass validation so it's rejected"
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/IndexedErrorMessage"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/beacon/pool/attestations.yaml
+++ b/apis/beacon/pool/attestations.yaml
@@ -43,8 +43,8 @@ get:
 
 post:
   operationId: submitPoolAttestations
-  summary: Submit Attestation object to node
-  description: Submits Attestation object to node. If attestation passes all validation constraints, node MUST publish attestation on appropriate subnet.
+  summary: Submit Attestation objects to node
+  description: Submits Attestation objects to node. If attestations pass all validation constraints, node MUST publish attestations on appropriate subnet.
   tags:
     - Beacon
     - ValidatorRequiredApi
@@ -53,10 +53,12 @@ post:
     content:
       application/json:
         schema:
-          $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Attestation'
+          type: array
+          items:
+            $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Attestation'
   responses:
     "200":
-      description: Attestation is stored in pool and broadcast on appropriate subnet
+      description: Attestations are stored in pool and broadcast on appropriate subnet
     "400":
       description: "Invalid attestation"
       content:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -182,6 +182,8 @@ components:
       $ref: './types/primitive.yaml#/Signature'
     ErrorMessage:
       $ref: './types/http.yaml#/ErrorMessage'
+    IndexedErrorMessage:
+      $ref: './types/http.yaml#/IndexedErrorMessage'
 
   parameters:
     StateId:

--- a/types/http.yaml
+++ b/types/http.yaml
@@ -83,7 +83,6 @@ NotFound:
       example:
         code: 404
         message: "Requested item not found"
-
 ErrorMessage:
   type: object
   properties:
@@ -99,3 +98,28 @@ ErrorMessage:
       type: array
       items:
         type: string
+IndexedErrorMessage:
+  type: object
+  properties:
+    code:
+      description: "Either specific error code in case of invalid request or http status code"
+      type: number
+      example: 400
+    message:
+      description: "Message describing error"
+      type: string
+      example: "some failures"
+    failures:
+      description: "List of individual items that have failed"
+      type: array
+      items:
+        type: object
+        properties:
+          index:
+            description: "Index of item in the request list that caused the error"
+            type: number
+            example: 3
+          message:
+            description: "Message describing error"
+            type: string
+            example: "invalid signature"


### PR DESCRIPTION
At current the POST to `/eth/v1/beacon/pool/attestations` takes a single `Attestation`.  This PR proposes that this is changed to an array of `Attestation`s.

Rationale behind this is that beacon nodes often carry out a fair chunk of work to decide if to accept and/or broadcast an attestation.  This can include processing slots to obtain the relevant state, validating attestations against said state, and checking for the existence of subnets to broadcast the attestation.  These operations are commonly repeated for each attestation, which means that if a validator client has multiple attestations to submit for the same slot it can lead to more work, longer delays before broadcasting attestations, and ultimately a less efficient network.

To provide more concrete information related to the above, the following is a histogram of response times for submitting individual attestations against a current beacon node:

![screenshot_2020-10-21-170123](https://user-images.githubusercontent.com/511384/96746462-1a8c0f80-13bf-11eb-9701-c2bdaf292b7f.png)

The validator client submits approximately 90 attestations per slot.  It can be seen that most of them are processed relatively quickly, however many attestations take over 1/2 a second to process, and there are a number of occasions where the time to process an attestation is over 4 seconds.  Note that although this graph is for a single beacon node, similar results have been seen with other beacon node implementations.

By providing multiple attestations at the same time it is possible for beacon nodes to significantly reduce duplicate work and reduce the duration from start of slot to time broadcast last attestation for the slot.  Note that testing with fewer attestations per slot the entire graph shifts to the left but retains a similar shape, implying that even with smaller numbers of attestations beacon nodes will be more efficient if they receive multiple attestations in a single request.