### PR TITLE
add 404 code to getState as a possible response

### DIFF
--- a/apis/debug/state.yaml
+++ b/apis/debug/state.yaml
@@ -29,6 +29,16 @@ get:
               - example:
                   code: 400
                   message: "Invalid state ID: current"
+    "404":
+      description: "State not found"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 404
+                  message: "State not found"
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
 


### PR DESCRIPTION
Hopefully this is fairly clear - get by id should have a possible 404 code, as is done through most of the api.