### PR TITLE
Rename 'attestation' to 'aggregate' in SignedAggregateAndProof.

### DIFF
--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -90,7 +90,7 @@ Aggregate:
   properties:
     aggregator_index:
       $ref: './primitive.yaml#/Uint64'
-    attestation:
+    aggregate:
       $ref: './attestation.yaml#/Attestation'
 
 


### PR DESCRIPTION
As per @realbigsean this renames a field in `SignedAggregateAndProof` to match that in the official spec.

Fixes #106 