### PR TITLE
Add validator index to validator subscriptions

### DIFF
--- a/apis/validator/beacon_committee_subscriptions.yaml
+++ b/apis/validator/beacon_committee_subscriptions.yaml
@@ -20,6 +20,8 @@ post:
           items:
             type: object
             properties:
+              validator_index:
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
               committee_index:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
               committees_at_slot:


### PR DESCRIPTION
Currently, at least two Eth2.0 clients (Lighthouse and Teku) require a validator index to be submitted along with the validator subscriptions API call. 

As pointed out in https://github.com/ethereum/eth2.0-APIs/issues/98 it may be possible to infer validator subscription counts from rates of subscription calls. The current API requires beacon nodes to do this. 

This PR supports both approaches, allowing any implementation to continue to infer validator counts by request rates but also supports Lighthouse's and Teku's current implementations by adding the validator index to the subscription call. This adds further information that allow the beacon node to know which exact validators are performing subscriptions. 

I think the overhead of adding a single uint64 is minimal compared to the work of changing multiple client implementations plus we gain the extra useful information (the validator making the subscription) sent to beacon nodes.

