### PR TITLE
add state not found possibility to state validators endpoint

### DIFF
--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -54,6 +54,16 @@ get:
               - example:
                   code: 400
                   message: "Invalid state ID: current"
+    "404":
+      description: "State not found"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 404
+                  message: "State not found"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
 

--- a/apis/debug/state.yaml
+++ b/apis/debug/state.yaml
@@ -7,8 +7,13 @@ get:
   parameters:
     - name: state_id
       in: path
+      example: "head"
       required: true
-      $ref: '../../beacon-node-oapi.yaml#/components/parameters/StateId'
+      schema:
+        type: string
+      description: |
+        State identifier.
+        Can be one of: "head" (canonical head in node's view), "genesis", "finalized", "justified", \<slot\>, \<hex encoded stateRoot with 0x prefix\>.
   responses:
     "200":
       description: Success

--- a/apis/debug/state.yaml
+++ b/apis/debug/state.yaml
@@ -7,6 +7,7 @@ get:
   parameters:
     - name: state_id
       in: path
+      required: true
       $ref: '../../beacon-node-oapi.yaml#/components/parameters/StateId'
   responses:
     "200":


### PR DESCRIPTION
Similar to other endpoints pulling data from the beacon state, it's possible to not be able to retrieve a state when this request is made.

The state_id parameter is valid, but the state was not fetchable, (bytes32 didn't exist is one possibility, or the state is not retrievable for another reason)

This is distinct from a 400 error where it might be invalid input (state_id = "current" would be a 400), and it is useful to determine that the state isn't available vs. the user has requested invalid data.