### PR TITLE
Make epoch parameter query rather than path

### DIFF
--- a/apis/beacon/states/committee.yaml
+++ b/apis/beacon/states/committee.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: "getEpochCommittees"
-  summary: "Get all committees for epoch"
-  description: "Retrieves the committees for the given state at the given epoch."
+  summary: "Get all committees for a state."
+  description: "Retrieves the committees for the given state."
   tags:
     - Beacon
   parameters:
@@ -9,16 +9,16 @@ get:
       in: path
       $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
     - name: epoch
-      description: "Epoch for which to calculate committees. Defaults to beacon state epoch."
-      in: path
-      required: true
-      allowEmptyValue: true
+      description: "Fetch committees for the given epoch.  If not present then the committees for the epoch of the state will be obtained."
+      in: query
+      required: false
+      allowEmptyValue: false
       schema:
         allOf:
           - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
           - example: ""
     - name: index
-      description: "Committee index"
+      description: "Restrict returned values to those matching the supplied committee index."
       in: query
       required: false
       schema:
@@ -26,14 +26,13 @@ get:
           - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
           - example: ""
     - name: slot
+      description: "Restrict returned values to those matching the supplied slot."
       in: query
       required: false
       schema:
         allOf:
           - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
           - example: ""
-
-
   responses:
     "200":
       description: Success

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -52,7 +52,7 @@ paths:
     $ref: "./apis/beacon/states/validator.yaml"
   /eth/v1/beacon/states/{state_id}/validator_balances:
     $ref: "./apis/beacon/states/validator_balances.yaml"
-  /eth/v1/beacon/states/{state_id}/committees/{epoch}:
+  /eth/v1/beacon/states/{state_id}/committees:
     $ref: "./apis/beacon/states/committee.yaml"
   /eth/v1/beacon/headers:
     $ref: "./apis/beacon/blocks/headers.yaml"


### PR DESCRIPTION
As per #108, this moves the optional `epoch` parameter from being a path parameter to a query parameter.  It also expands on the use of other query parameters as filters.