### PR TITLE
Convert chain ID to uint64

### DIFF
--- a/apis/config/deposit_contract.yaml
+++ b/apis/config/deposit_contract.yaml
@@ -17,11 +17,10 @@ get:
                 type: object
                 properties:
                   chain_id:
-                    description: Id of Eth1 chain on which contract is deployed.
-                    type: integer
-                    format: int32
-                    example: 1
-                    minimum: 1
+                    allOf:
+                      - $ref: ../../beacon-node-oapi.yaml#/components/schemas/Uint64
+                      - description: Id of Eth1 chain on which contract is deployed.
+                      - example: "1"
                   address:
                     allOf:
                       - $ref: ../../beacon-node-oapi.yaml#/components/schemas/Hex


### PR DESCRIPTION
Ethereum 1 chain ID is an anomaly in that it is presented as a number rather than a string.  This changes the value to be a uint64, and hence presented as a string, as per the conversation at https://discord.com/channels/595666850260713488/710831784991916072/775098382095482910.