### PR TITLE
Specify that SSE events must contain valid objects

### DIFF
--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -41,19 +41,19 @@ get:
                 data: "{\"slot\": \"10\", \"block\": \"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf\", \"state\":\"0x600e852a08c1200654ddf11025f1ceacb3c2e74bdd5c630cde0838b2591b69f9\", \"epoch_transition\": false}"\n
                 \n
             block:
-              description: The node has received a block (from P2P or API)
+              description: The node has received a valid block (from P2P or API)
               value: |
                 event: block\n
                 data: "{\"slot\": \"10\", \"block\": \"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf\"}"\n
                 \n
             attestation:
-              description: The node has received an attestation (from P2P or API)
+              description: The node has received a valid attestation (from P2P or API)
               value: |
                 event: attestation\n
                 data: "{\n      \"aggregation_bits\": \"0x01\",\n      \"signature\": \"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505\",\n      \"data\": {\n        \"slot\": \"1\",\n        \"index\": \"1\",\n        \"beacon_block_root\": \"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2\",\n        \"source\": {\n          \"epoch\": \"1\",\n          \"root\": \"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2\"\n        },\n        \"target\": {\n          \"epoch\": \"1\",\n          \"root\": \"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2\"\n        }\n      }\n    }"\n
                 \n
             voluntary_exit:
-              description: The node has received a voluntary exit (from P2P or API)
+              description: The node has received a valid voluntary exit (from P2P or API)
               value: |
                 event: voluntary_exit\n
                 data: "{\n      \"message\": {\n        \"epoch\": \"1\",\n        \"validator_index\": \"1\"\n      },\n      \"signature\": \"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505\"\n    }"\n


### PR DESCRIPTION
I've specified that objects sent on SSE events must be valid. This PR serves to provide my suggestion (see code changes) and gather feedback from others.

### Pros for including invalid objects

- Allows for identifying faulty validators.
- Probably useful for research.

### Cons for including invalid objects

- Introduces the only scenario where we tell API consumers about invalid objects.
    - If we go down this path, I think we must have a `valid` field on those objects.
- Potentially opens our API consumers up to damage from DoS attacks.