### PR TITLE
Add dependent_root metadata to attestation and block duties

### DIFF
--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -35,7 +35,7 @@ get:
             description: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format
           examples:
             head:
-              description: The node has finished processing, resulting in a new head
+              description: The node has finished processing, resulting in a new head. previous_duty_dependent_root is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)` and current_duty_dependent_root is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch) - 1)`. Both use the genesis block root in the case of underflow
               value: |
                 event: head\n
                 data: "{\"slot\": \"10\", \"block\": \"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf\", \"state\":\"0x600e852a08c1200654ddf11025f1ceacb3c2e74bdd5c630cde0838b2591b69f9\", \"epoch_transition\": false, \"previous_duty_dependent_root\": \"0x5e0043f107cb57913498fbf2f99ff55e730bf1e151f02f221e977c91a90a0e91\", \"current_duty_dependent_root\": \"0x5e0043f107cb57913498fbf2f99ff55e730bf1e151f02f221e977c91a90a0e91\"}"\n

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -38,7 +38,7 @@ get:
               description: The node has finished processing, resulting in a new head
               value: |
                 event: head\n
-                data: "{\"slot\": \"10\", \"block\": \"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf\", \"state\":\"0x600e852a08c1200654ddf11025f1ceacb3c2e74bdd5c630cde0838b2591b69f9\", \"epoch_transition\": false}"\n
+                data: "{\"slot\": \"10\", \"block\": \"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf\", \"state\":\"0x600e852a08c1200654ddf11025f1ceacb3c2e74bdd5c630cde0838b2591b69f9\", \"epoch_transition\": false, \"previous_duty_dependent_root\": \"0x5e0043f107cb57913498fbf2f99ff55e730bf1e151f02f221e977c91a90a0e91\", \"current_duty_dependent_root\": \"0x5e0043f107cb57913498fbf2f99ff55e730bf1e151f02f221e977c91a90a0e91\"}"\n
                 \n
             block:
               description: The node has received a valid block (from P2P or API)

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -35,7 +35,7 @@ get:
             description: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format
           examples:
             head:
-              description: The node has finished processing, resulting in a new head. previous_duty_dependent_root is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)` and current_duty_dependent_root is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch) - 1)`. Both use the genesis block root in the case of underflow
+              description: The node has finished processing, resulting in a new head. previous_duty_dependent_root is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)` and current_duty_dependent_root is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch) - 1)`. Both dependent roots use the genesis block root in the case of underflow.
               value: |
                 event: head\n
                 data: "{\"slot\": \"10\", \"block\": \"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf\", \"state\":\"0x600e852a08c1200654ddf11025f1ceacb3c2e74bdd5c630cde0838b2591b69f9\", \"epoch_transition\": false, \"previous_duty_dependent_root\": \"0x5e0043f107cb57913498fbf2f99ff55e730bf1e151f02f221e977c91a90a0e91\", \"current_duty_dependent_root\": \"0x5e0043f107cb57913498fbf2f99ff55e730bf1e151f02f221e977c91a90a0e91\"}"\n

--- a/apis/validator/duties/attester.yaml
+++ b/apis/validator/duties/attester.yaml
@@ -11,7 +11,10 @@ post:
     however a chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur,
     resulting in a change of duties. For full safety, you should monitor head events and confirm the
     previous_duty_dependent_root or current_duty_dependent_root in the head event matches the
-    dependent_root in this response."
+    dependent_root in this response.
+
+    The dependent_root value is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)`
+    or the genesis block root in the case of underflow."
   parameters:
     - name: epoch
       description: "Should only be allowed 1 epoch ahead"

--- a/apis/validator/duties/attester.yaml
+++ b/apis/validator/duties/attester.yaml
@@ -10,8 +10,13 @@ post:
     Duties should only need to be checked once per epoch,
     however a chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur,
     resulting in a change of duties. For full safety, you should monitor head events and confirm the
-    previous_duty_dependent_root or current_duty_dependent_root in the head event matches the
-    dependent_root in this response.
+    dependent root in this response matches:
+
+      - event.previous_duty_dependent_root when `compute_epoch_at_slot(event.slot) == epoch`
+
+      - event.current_duty_dependent_root when `compute_epoch_at_slot(event.slot) + 1 == epoch`
+
+      - event.block otherwise
 
     The dependent_root value is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)`
     or the genesis block root in the case of underflow."

--- a/apis/validator/duties/attester.yaml
+++ b/apis/validator/duties/attester.yaml
@@ -9,7 +9,9 @@ post:
 
     Duties should only need to be checked once per epoch,
     however a chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur,
-    resulting in a change of duties. For full safety, you should monitor chain reorganizations events."
+    resulting in a change of duties. For full safety, you should monitor head events and confirm the
+    previous_duty_dependent_root or current_duty_dependent_root in the head event matches the
+    dependent_root in this response."
   parameters:
     - name: epoch
       description: "Should only be allowed 1 epoch ahead"
@@ -37,6 +39,8 @@ post:
             title: GetAttesterDutiesResponse
             type: object
             properties:
+              dependent_root:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/DependentRoot"
               data:
                 type: array
                 items:

--- a/apis/validator/duties/proposer.yaml
+++ b/apis/validator/duties/proposer.yaml
@@ -10,7 +10,10 @@ get:
     however a chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur,
     resulting in a change of duties. For full safety, you should monitor head events and confirm the
     previous_duty_dependent_root or current_duty_dependent_root in the head event matches the
-    dependent_root in this response."
+    dependent_root in this response.
+
+    The dependent_root value is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch) - 1)`
+    or the genesis block root in the case of underflow."
   parameters:
     - name: epoch
       in: path

--- a/apis/validator/duties/proposer.yaml
+++ b/apis/validator/duties/proposer.yaml
@@ -7,9 +7,8 @@ get:
   description: "Request beacon node to provide all validators that are scheduled to propose a block in the given epoch.
 
     Duties should only need to be checked once per epoch,
-    however a chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur,
-    resulting in a change of duties. For full safety, you should monitor head events and confirm the
-    dependent root in this response matches:
+    however a chain reorganization could occur that results in a change of duties. For full safety,
+    you should monitor head events and confirm the dependent root in this response matches:
 
      - event.current_duty_dependent_root when `compute_epoch_at_slot(event.slot) == epoch`
 

--- a/apis/validator/duties/proposer.yaml
+++ b/apis/validator/duties/proposer.yaml
@@ -4,7 +4,13 @@ get:
     - Validator
   summary: "Get block proposers duties"
   operationId: "getProposerDuties"
-  description: "Request beacon node to provide all validators that are scheduled to propose a block in the given epoch"
+  description: "Request beacon node to provide all validators that are scheduled to propose a block in the given epoch.
+
+    Duties should only need to be checked once per epoch,
+    however a chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur,
+    resulting in a change of duties. For full safety, you should monitor head events and confirm the
+    previous_duty_dependent_root or current_duty_dependent_root in the head event matches the
+    dependent_root in this response."
   parameters:
     - name: epoch
       in: path
@@ -20,6 +26,8 @@ get:
             title: GetProposerDutiesResponse
             type: object
             properties:
+              dependent_root:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/DependentRoot"
               data:
                 type: array
                 items:

--- a/apis/validator/duties/proposer.yaml
+++ b/apis/validator/duties/proposer.yaml
@@ -9,8 +9,11 @@ get:
     Duties should only need to be checked once per epoch,
     however a chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur,
     resulting in a change of duties. For full safety, you should monitor head events and confirm the
-    previous_duty_dependent_root or current_duty_dependent_root in the head event matches the
-    dependent_root in this response.
+    dependent root in this response matches:
+
+     - event.current_duty_dependent_root when `compute_epoch_at_slot(event.slot) == epoch`
+
+     - event.block otherwise
 
     The dependent_root value is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch) - 1)`
     or the genesis block root in the case of underflow."

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -178,6 +178,8 @@ components:
       $ref: './types/primitive.yaml#/Version'
     ForkVersion:
       $ref: './types/primitive.yaml#/ForkVersion'
+    DependentRoot:
+      $ref: './types/primitive.yaml#/DependentRoot'
     Root:
       $ref: './types/primitive.yaml#/Root'
     Hex:

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -31,7 +31,7 @@ Uint64:
 DependentRoot:
   allOf:
     - $ref: "./primitive.yaml#/Root"
-    - description: "The block root that this response is dependent on. The data in this response is accurate only when the block with this root is on the canonical chain."
+    - description: "The block root that this response is dependent on."
 
 Root:
   type: string

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -28,6 +28,11 @@ Uint64:
   type: string
   example: "1"
 
+DependentRoot:
+  allOf:
+    - $ref: "./primitive.yaml#/Root"
+    - description: "The block root that this response is dependent on. The data in this response is accurate only when the block with this root is on the canonical chain."
+
 Root:
   type: string
   example: "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"


### PR DESCRIPTION
Based on a proposal by @paulhauner (https://github.com/ethereum/eth2.0-APIs/issues/116#issuecomment-725866624), adds additional `dependent_root` fields which make it possible for validator clients to accurately determine when a chain reorg or block import has caused previously calculated duties to become invalid.  The previous approach only said to monitor `chain_reorg` events but didn't provide any guarantee that `chain_reorg` events would be published in all cases that could require invalidating duties.  See https://hackmd.io/kutQ7smJRZ-sJNSuY1WWVA#Why-head-must-be-published-for-empty-slots for an explanation of the scenario that is typically missed.

In this variant of the proposal, the `target_root` is included as a `dependent_root` metadata property for the attester and proposer duties responses. This avoids the need to break backwards compatibility by changing the `data` property from an object to an array and establishes a potentially useful concept of explicitly declaring the chain state that a response is dependent on.  Which slot the block root must exist in isn't explicitly specified in the response but is defined in the description.

`current_duty_dependent_root` and `previous_duty_dependent_root` are then added to the `head` event, so that validator clients are able to determine when existing duties have been invalided.

`head` events are then only required when a new block is imported or when a reorg changes the head block, but not when the chain head state progresses due to an empty slot (and beacon nodes are then free to skip processing empty slots).