### PR TITLE
Add is_syncing to /node/syncing

### DIFF
--- a/apis/node/syncing.yaml
+++ b/apis/node/syncing.yaml
@@ -25,5 +25,8 @@
                       allOf:
                         - description: "How many slots node needs to process to reach head. 0 if synced."
                         - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+                    is_syncing:
+                      type: boolean
+                      description: "Set to true if the node is syncing, false if the node is synced."
       "500":
         $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'


### PR DESCRIPTION
## Proposed Changes

Adds the `is_syncing: bool`field to the `../node/syncing` endpoint as per the reasons documented here: https://github.com/ethereum/eth2.0-APIs/issues/77#issuecomment-759164934

## Additional Info

I would like to change `head_slot` to refer to *the block at the head of the canonical chain*,for consistency with the other uses of "head" in this API. I've left that out of this PR since that's a non-backwards-compatible change and I'd like to get this merged regardless of that change.