### PR TITLE
Fix description of config/deposit_contract

### DIFF
--- a/apis/config/deposit_contract.yaml
+++ b/apis/config/deposit_contract.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: getDepositContract
   summary: Get deposit contract address.
-  description: Retrieve deposit contract address and genesis fork version.
+  description: Retrieve Eth1 deposit contract address and chain ID.
   tags:
     - Config
   responses:


### PR DESCRIPTION
The description of `config/deposit_contract` is incorrect, as it talks about a genesis fork version, when it's the Eth1 chain ID which should be returned.