### PR TITLE
Allow for null reorg distance

### DIFF
--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -65,7 +65,7 @@ get:
                 data: "{\"block\":\"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf\", \"state\": \"0x600e852a08c1200654ddf11025f1ceacb3c2e74bdd5c630cde0838b2591b69f9\", \"epoch\": \"2\" }"\n
                 \n
             chain_reorg:
-              description: The node has reorganized its chain
+              description: The node has reorganized its chain. The `depth` value may be `null` if the server is unable to compute the distance.
               value: |
                 event: chain_reorg\n
                 data: "{\"slot\":\"200\", \"depth\": \"50\", \"old_head_block\": \"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf\", \"new_head_block\": \"0x76262e91970d375a19bfe8a867288d7b9cde43c8635f598d93d39d041706fc76\", \"old_head_state\":\"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf\", \"new_head_state\": \"0x600e852a08c1200654ddf11025f1ceacb3c2e74bdd5c630cde0838b2591b69f9\", \"epoch\": \"2\" }"\n


### PR DESCRIPTION
We've been having a conversation about the reorg event [`depth`](https://github.com/ethereum/eth2.0-APIs/blob/e36b026ef1265dba9b9c6bc984236088d3759f87/apis/eventstream/index.yaml#L71) in https://github.com/sigp/lighthouse/pull/2090.

The problem is that computing the re-org distance involves finding the highest common ancestor of two blocks. This is a notoriously difficult problem in blockchains which is resistant to optimization and typically involves an `O(n)` walk back through the chain.

In Eth2, computing that re-org distance is quite easy *if the re-org is not deeper than `SLOTS_PER_HISTORICAL_ROOT` (`8,192`) blocks*, since clients probably have all those block roots sitting in memory (they're in the `BeaconState`). However, once we go past 8,192 we're entering the territory of reading `BeaconState`s from the database or doing block-by-block reads from the DB.

My concern is that if the chain is very unhealthy and the head is bouncing around then the BN is committed to constantly computing the correct re-org depth for consumers of the event stream. In this PR I've explicitly added the ability for nodes to return `null` and save themselves from entering this `O(n)` search.