### PR TITLE
Create v2 of getState, which supports an Altair state object being returned

### DIFF
--- a/apis/debug/state.v2.yaml
+++ b/apis/debug/state.v2.yaml
@@ -9,6 +9,7 @@ get:
   parameters:
     - name: state_id
       in: path
+      required: true
       $ref: '../../beacon-node-oapi.yaml#/components/parameters/StateId'
   responses:
     "200":

--- a/apis/debug/state.v2.yaml
+++ b/apis/debug/state.v2.yaml
@@ -9,13 +9,7 @@ get:
   parameters:
     - name: state_id
       in: path
-      example: "head"
-      required: true
-      schema:
-        type: string
-      description: |
-        State identifier.
-        Can be one of: "head" (canonical head in node's view), "genesis", "finalized", "justified", \<slot\>, \<hex encoded stateRoot with 0x prefix\>.
+      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
   responses:
     "200":
       description: Success

--- a/apis/debug/state.v2.yaml
+++ b/apis/debug/state.v2.yaml
@@ -9,7 +9,7 @@ get:
   parameters:
     - name: state_id
       in: path
-      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
+      $ref: '../../beacon-node-oapi.yaml#/components/parameters/StateId'
   responses:
     "200":
       description: Success

--- a/apis/debug/state.v2.yaml
+++ b/apis/debug/state.v2.yaml
@@ -1,0 +1,61 @@
+get:
+  operationId: "getStateV2"
+  summary: "Get full BeaconState object"
+  description: |
+     Returns full BeaconState object for given stateId.
+     Depending on `Accept` header it can be returned either as json or as bytes serialized by SSZ
+  tags:
+    - Debug
+  parameters:
+    - name: state_id
+      in: path
+      example: "head"
+      required: true
+      schema:
+        type: string
+      description: |
+        State identifier.
+        Can be one of: "head" (canonical head in node's view), "genesis", "finalized", "justified", \<slot\>, \<hex encoded stateRoot with 0x prefix\>.
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            title: GetStateV2Response
+            type: object
+            properties:
+              version:
+                type: string
+                enum: [ phase0, altair ]
+                example: "phase0"
+              data:
+                oneOf:
+                 - $ref: '../../beacon-node-oapi.yaml#/components/schemas/BeaconState'
+                 - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Altair.BeaconState"
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized state bytes. Use Accept header to choose this response type"
+    "400":
+      description: "Invalid state ID"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Invalid state ID: current"
+    "404":
+      description: "State not found"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 404
+                  message: "State not found"
+    "500":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
+

--- a/apis/debug/state.yaml
+++ b/apis/debug/state.yaml
@@ -9,6 +9,7 @@ get:
   parameters:
     - name: state_id
       in: path
+      required: true
       $ref: '../../beacon-node-oapi.yaml#/components/parameters/StateId'
   responses:
     "200":

--- a/apis/debug/state.yaml
+++ b/apis/debug/state.yaml
@@ -9,13 +9,7 @@ get:
   parameters:
     - name: state_id
       in: path
-      example: "head"
-      required: true
-      schema:
-        type: string
-      description: |
-        State identifier.
-        Can be one of: "head" (canonical head in node's view), "genesis", "finalized", "justified", \<slot\>, \<hex encoded stateRoot with 0x prefix\>.
+      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
   responses:
     "200":
       description: Success

--- a/apis/debug/state.yaml
+++ b/apis/debug/state.yaml
@@ -9,7 +9,7 @@ get:
   parameters:
     - name: state_id
       in: path
-      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
+      $ref: '../../beacon-node-oapi.yaml#/components/parameters/StateId'
   responses:
     "200":
       description: Success

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -87,6 +87,8 @@ paths:
 
   /eth/v1/debug/beacon/states/{state_id}:
     $ref: './apis/debug/state.yaml'
+  /eth/v2/debug/beacon/states/{state_id}:
+    $ref: './apis/debug/state.v2.yaml'
   /eth/v1/debug/beacon/heads:
     $ref: './apis/debug/heads.yaml'
 
@@ -203,6 +205,8 @@ components:
       $ref: './types/http.yaml#/IndexedErrorMessage'
     Altair.SignedBeaconBlock:
       $ref: './types/altair/block.yaml#/Altair/SignedBeaconBlock'
+    Altair.BeaconState:
+      $ref: './types/altair/state.yaml#/Altair/BeaconState'
 
   parameters:
     StateId:

--- a/types/altair/block.yaml
+++ b/types/altair/block.yaml
@@ -22,7 +22,7 @@ Altair:
 
   BeaconBlockBody:
     type: object
-    description: "The [`BeaconBlockBody`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.1/specs/altair/beacon-chain.md#beaconblockbody) object from the Eth2.0 Altair spec."
+    description: "The [`BeaconBlockBody`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#beaconblockbody) object from the Eth2.0 Altair spec."
     properties:
       randao_reveal:
         allOf:
@@ -57,7 +57,7 @@ Altair:
         $ref: './sync_aggregate.yaml#/Altair/SyncAggregate'
 
   BeaconBlock:
-    description: "The [`BeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.1/specs/altair/beacon-chain.md#beaconblock) object from the Eth2.0 Altair spec."
+    description: "The [`BeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#beaconblock) object from the Eth2.0 Altair spec."
     allOf:
       - $ref: '#/Altair/BeaconBlockCommon'
       - type: object
@@ -67,7 +67,7 @@ Altair:
 
   SignedBeaconBlock:
     type: object
-    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.1/specs/altair/beacon-chain.md#signedbeaconblock) object envelope from the Eth2.0 Altair spec."
+    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#signedbeaconblock) object envelope from the Eth2.0 Altair spec."
     properties:
       message:
         $ref: "#/Altair/BeaconBlock"

--- a/types/altair/epoch_participation.yaml
+++ b/types/altair/epoch_participation.yaml
@@ -1,0 +1,7 @@
+Altair:
+  EpochParticipation:
+    type: array
+    items:
+      allOf:
+        - $ref: '../primitive.yaml#/Uint8'
+    maxItems: 1099511627776

--- a/types/altair/state.yaml
+++ b/types/altair/state.yaml
@@ -1,0 +1,99 @@
+Altair:
+  BeaconState:
+    type: object
+    description: "The [`BeaconState`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#beaconstate) object from the Eth2.0 Altair spec."
+    properties:
+      genesis_time:
+        $ref: "../primitive.yaml#/Uint64"
+      genesis_validators_root:
+        $ref: "../primitive.yaml#/Root"
+      slot:
+        $ref: "../primitive.yaml#/Uint64"
+      fork:
+        $ref: "../misc.yaml#/Fork"
+      latest_block_header:
+        $ref: "../block.yaml#/BeaconBlockHeader"
+      block_roots:
+        type: array
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Root'
+        minItems: 8192
+        maxItems: 8192
+      state_roots:
+        type: array
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Root'
+        minItems: 8192
+        maxItems: 8192
+      historical_roots:
+        type: array
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Root'
+        maxItems: 16777216
+      eth1_data:
+        $ref: "../eth1.yaml#/Eth1Data"
+      eth1_data_votes:
+        type: array
+        items:
+          allOf:
+            - $ref: '../eth1.yaml#/Eth1Data'
+        maxItems: 1024
+      eth1_deposit_index:
+        $ref: "../primitive.yaml#/Uint64"
+      validators:
+        type: array
+        maxItems: 1099511627776
+        items:
+          allOf:
+            - $ref: '../validator.yaml#/Validator'
+      balances:
+        type: array
+        description: "Validator balances in gwei"
+        maxItems: 1099511627776
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Uint64'
+      randao_mixes:
+        type: array
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Root'
+        minItems: 65536
+        maxItems: 65536
+      slashings:
+        type: array
+        description: "Per-epoch sums of slashed effective balances"
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Uint64'
+        minItems: 8192
+        maxItems: 8192
+      previous_epoch_participation:
+        $ref: './epoch_participation.yaml#/Altair/EpochParticipation'
+      current_epoch_participation:
+        $ref: './epoch_participation.yaml#/Altair/EpochParticipation'
+      justification_bits:
+        type: string
+        pattern: "^0x[a-fA-F0-9]+$"
+        example: "0x01"
+        description: "Bit set for every recent justified epoch"
+      previous_justified_checkpoint:
+        $ref: "../misc.yaml#/Checkpoint"
+      current_justified_checkpoint:
+        $ref: "../misc.yaml#/Checkpoint"
+      finalized_checkpoint:
+        $ref: "../misc.yaml#/Checkpoint"
+      inactivity_scores:
+        description: "Per-validator inactivity scores. New in Altair"
+        type: array
+        maxItems: 1099511627776
+        items:
+          allOf:
+            - $ref: "../primitive.yaml#/Uint64"
+      current_sync_committee:
+        $ref: "./sync_committee.yaml#/Altair/SyncCommittee"
+      next_sync_committee:
+        $ref: './sync_committee.yaml#/Altair/SyncCommittee'

--- a/types/altair/sync_committee.yaml
+++ b/types/altair/sync_committee.yaml
@@ -1,0 +1,18 @@
+Altair:
+  SyncCommittee:
+    type: object
+    properties:
+      pubkeys:
+        type: array
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Pubkey'
+        minItems: 1024
+        maxItems: 1024
+      pubkey_aggregates:
+        type: array
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Pubkey'
+        minItems: 16
+        maxItems: 16

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -52,3 +52,8 @@ Signature:
   type: string
   pattern: "^0x[a-fA-F0-9]{192}$"
   example: "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"
+
+Uint8:
+  type: string
+  pattern: "^0x[a-fA-F0-9]{2}$"
+  example: "0xff"

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -55,5 +55,6 @@ Signature:
 
 Uint8:
   type: string
-  pattern: "^0x[a-fA-F0-9]{2}$"
-  example: "0xff"
+  description: "Unsigned 8 bit integer, max value 255"
+  pattern: "^[1-2]?[0-9]{1,2}$"
+  example: "0"


### PR DESCRIPTION
In a similar design to GetBlockV2, GetStateV2 can return phase0 or altair states.

Also updated links in GetBlockV2 to refer to the newer spec, after validating there are no new changes.