### PR TITLE
add `/eth/v1/validator/duties/sync/{epoch}`

### DIFF
--- a/apis/validator/duties/sync.yaml
+++ b/apis/validator/duties/sync.yaml
@@ -7,7 +7,7 @@ post:
   description: "Requests the beacon node to provide a set of sync committee duties for a particular epoch."
   parameters:
     - name: epoch
-      description: "Should only be allowed 1 epoch ahead"
+      description: "epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD <= current_epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD + 1"
       in: path
       required: true
       schema:

--- a/apis/validator/duties/sync.yaml
+++ b/apis/validator/duties/sync.yaml
@@ -1,0 +1,68 @@
+post:
+  tags:
+    - ValidatorRequiredApi
+    - Validator
+  summary: "Get sync committee duties"
+  operationId: "getSyncCommitteeDuties"
+  description: "Requests the beacon node to provide a set of sync committee duties for a particular epoch.
+
+    Duties should only need to be checked once per epoch,
+    however a chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur,
+    resulting in a change of duties. For full safety, you should monitor head events and confirm the
+    dependent root in this response matches:
+
+      - event.previous_duty_dependent_root when `compute_epoch_at_slot(event.slot) == epoch`
+
+      - event.current_duty_dependent_root when `compute_epoch_at_slot(event.slot) + 1 == epoch`
+
+      - event.block otherwise
+
+    The dependent_root value is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)`
+    or the genesis block root in the case of underflow."
+  parameters:
+    - name: epoch
+      description: "Should only be allowed 1 epoch ahead"
+      in: path
+      required: true
+      schema:
+        $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+  requestBody:
+    description: "An array of the validator indices for which to obtain the duties."
+    required: true
+    content:
+      application/json:
+        schema:
+          title: GetSyncCommitteeDutiesBody
+          type: array
+          items:
+            $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+            minItems: 1
+  responses:
+    "200":
+      description: Success response
+      content:
+        application/json:
+          schema:
+            title: GetSyncCommitteeDutiesResponse
+            type: object
+            properties:
+              dependent_root:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/DependentRoot"
+              data:
+                type: array
+                items:
+                  $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.SyncDuty'
+    "400":
+      description: "Invalid epoch or index"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Invalid epoch: -2"
+    "500":
+      $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
+    "503":
+      $ref: '../../../beacon-node-oapi.yaml#/components/responses/CurrentlySyncing'

--- a/apis/validator/duties/sync.yaml
+++ b/apis/validator/duties/sync.yaml
@@ -4,21 +4,7 @@ post:
     - Validator
   summary: "Get sync committee duties"
   operationId: "getSyncCommitteeDuties"
-  description: "Requests the beacon node to provide a set of sync committee duties for a particular epoch.
-
-    Duties should only need to be checked once per epoch,
-    however a chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur,
-    resulting in a change of duties. For full safety, you should monitor head events and confirm the
-    dependent root in this response matches:
-
-      - event.previous_duty_dependent_root when `compute_epoch_at_slot(event.slot) == epoch`
-
-      - event.current_duty_dependent_root when `compute_epoch_at_slot(event.slot) + 1 == epoch`
-
-      - event.block otherwise
-
-    The dependent_root value is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)`
-    or the genesis block root in the case of underflow."
+  description: "Requests the beacon node to provide a set of sync committee duties for a particular epoch."
   parameters:
     - name: epoch
       description: "Should only be allowed 1 epoch ahead"

--- a/apis/validator/duties/sync.yaml
+++ b/apis/validator/duties/sync.yaml
@@ -46,8 +46,6 @@ post:
             title: GetSyncCommitteeDutiesResponse
             type: object
             properties:
-              dependent_root:
-                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/DependentRoot"
               data:
                 type: array
                 items:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -118,6 +118,8 @@ paths:
     $ref: "./apis/validator/duties/attester.yaml"
   /eth/v1/validator/duties/proposer/{epoch}:
     $ref: "./apis/validator/duties/proposer.yaml"
+  /eth/v1/validator/duties/sync/{epoch}:
+    $ref: "./apis/validator/duties/sync.yaml"
   /eth/v1/validator/blocks/{slot}:
     $ref: "./apis/validator/block.yaml"
   /eth/v1/validator/attestation_data:
@@ -161,6 +163,8 @@ components:
       $ref: './types/validator.yaml#/AttesterDuty'
     ProposerDuty:
       $ref: './types/validator.yaml#/ProposerDuty'
+    Altair.SyncDuty:
+      $ref: './types/validator.yaml#/Altair/SyncDuty'
     SignedAggregateAndProof:
       $ref: './types/validator.yaml#/SignedAggregateAndProof'
     Attestation:

--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -91,7 +91,7 @@ Altair:
         description: "The indices of the validator in the sync committee."
         minItems: 1
         items:
-          $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+          $ref: './primitive.yaml#/Uint64'
 
 AggregateAndProof:
   allOf:

--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -86,10 +86,12 @@ Altair:
         allOf:
           - $ref: "./primitive.yaml#/Uint64"
           - description: "Index of validator in validator registry."
-      sync_committee_index:
-        allOf:
-          - $ref: "./primitive.yaml#/Uint64"
-          - description: "The index of the validator in the sync committee."
+      sync_committee_indices:
+        type: array
+        description: "The indices of the validator in the sync committee."
+        minItems: 1
+        items:
+          $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
 
 AggregateAndProof:
   allOf:

--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -76,6 +76,21 @@ ProposerDuty:
         - $ref: "./primitive.yaml#/Uint64"
         - description: "The slot at which the validator must propose block."
 
+Altair:
+  SyncDuty:
+    type: object
+    properties:
+      pubkey:
+        $ref: './primitive.yaml#/Pubkey'
+      validator_index:
+        allOf:
+          - $ref: "./primitive.yaml#/Uint64"
+          - description: "Index of validator in validator registry."
+      sync_committee_index:
+        allOf:
+          - $ref: "./primitive.yaml#/Uint64"
+          - description: "The index of the validator in the sync committee."
+
 AggregateAndProof:
   allOf:
     - $ref: '#/Aggregate'

--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -86,7 +86,7 @@ Altair:
         allOf:
           - $ref: "./primitive.yaml#/Uint64"
           - description: "Index of validator in validator registry."
-      sync_committee_indices:
+      validator_sync_committee_indices:
         type: array
         description: "The indices of the validator in the sync committee."
         minItems: 1


### PR DESCRIPTION
create a spec for sync committee duties for altair.

I'm open to making this more clearly altair specific, for now I've worked it into the typing information.

Basically I transcribed @mcdee hackmd from https://hackmd.io/@QYHAVYiHRg65pdI_CEm7Eg/syncommitteeapi#POST-ethv1validatordutiessyncepoch