### PR TITLE
add POST /eth/v1/validator/sync_committee_subscriptions

### DIFF
--- a/apis/validator/beacon_committee_subscriptions.yaml
+++ b/apis/validator/beacon_committee_subscriptions.yaml
@@ -34,7 +34,7 @@ post:
                   - description: "Should be slot at which validator is assigned to attest"
               is_aggregator:
                 type: boolean
-                description: "Signals to BN that a validator on the VC has been chosed for aggregator role."
+                description: "Signals to BN that a validator on the VC has been chosen for aggregator role."
 
   responses:
     "200":

--- a/apis/validator/sync_committee_subscriptions.yaml
+++ b/apis/validator/sync_committee_subscriptions.yaml
@@ -1,0 +1,27 @@
+post:
+  operationId: "syncCommitteeSubscriptions"
+  summary: "Subscribe to sync committee subnets"
+  description: |
+    Subscribe to a number of sync committee subnets
+
+    Sync committees are not present in phase0, but are required for Altair networks.
+
+    Subscribing to sync committee subnets is an action performed by VC to enable network participation in Altair networks, and only required if the VC has an active validator in an active sync committee.
+
+  tags:
+    - ValidatorRequiredApi
+    - Validator
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            $ref: '../../beacon-node-oapi.yaml#/components/schemas/Altair.SyncCommitteeSubscription'
+  responses:
+    "200":
+      description: "Successful response"
+    "400":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
+    "500":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/validator/sync_committee_subscriptions.yaml
+++ b/apis/validator/sync_committee_subscriptions.yaml
@@ -1,5 +1,5 @@
 post:
-  operationId: "syncCommitteeSubscriptions"
+  operationId: "prepareSyncCommitteeSubnets"
   summary: "Subscribe to sync committee subnets"
   description: |
     Subscribe to a number of sync committee subnets

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -128,6 +128,8 @@ paths:
     $ref: "./apis/validator/aggregate_and_proofs.yaml"
   /eth/v1/validator/beacon_committee_subscriptions:
     $ref: "./apis/validator/beacon_committee_subscriptions.yaml"
+  /eth/v1/validator/sync_committee_subscriptions:
+    $ref: "./apis/validator/sync_committee_subscriptions.yaml"
 
   /eth/v1/events:
     $ref: "./apis/eventstream/index.yaml"
@@ -207,6 +209,8 @@ components:
       $ref: './types/altair/block.yaml#/Altair/SignedBeaconBlock'
     Altair.BeaconState:
       $ref: './types/altair/state.yaml#/Altair/BeaconState'
+    Altair.SyncCommitteeSubscription:
+      $ref: './types/altair/sync_committee.yaml#/Altair/SyncCommitteeSubscription'
 
   parameters:
     StateId:

--- a/types/altair/sync_committee.yaml
+++ b/types/altair/sync_committee.yaml
@@ -16,3 +16,15 @@ Altair:
             - $ref: '../primitive.yaml#/Pubkey'
         minItems: 16
         maxItems: 16
+  SyncCommitteeSubscription:
+    type: object
+    properties:
+      validator_index:
+        $ref: '../primitive.yaml#/Uint64'
+      sub_committees:
+        type: array
+        items:
+          allOf:
+           - $ref: '../primitive.yaml#/Uint64'
+      until_epoch:
+        $ref: '../primitive.yaml#/Uint64'

--- a/types/altair/sync_committee.yaml
+++ b/types/altair/sync_committee.yaml
@@ -21,7 +21,7 @@ Altair:
     properties:
       validator_index:
         $ref: '../primitive.yaml#/Uint64'
-      sub_committees:
+      sync_committee_indices:
         type: array
         items:
           allOf:


### PR DESCRIPTION
https://hackmd.io/@QYHAVYiHRg65pdI_CEm7Eg/syncommitteeapi#POST-ethv1validatorsync_committee_subscriptions

notable differences:
 - `sync_committee_index` became an array: sync_committee_indices, as multiple subnets per validator is possible.

 - `is_aggregator` is not really needed in this instance as far as we can tell, and potentially won't be known at the time of making the subscription.

 - added `until_epoch` so that the BN can unsubscribe based on this request.