### PR TITLE
GET `/eth/v1/validator/sync_committee_contribution`

### DIFF
--- a/apis/validator/sync_committee_contribution.yaml
+++ b/apis/validator/sync_committee_contribution.yaml
@@ -1,0 +1,43 @@
+get:
+  tags:
+    - ValidatorRequiredApi
+    - Validator
+  operationId: "produceSyncCommitteeContribution"
+  summary: "Produce a sync committee contribution"
+  description: "Requests that the beacon node produce a sync committee contribution."
+  parameters:
+    - name: slot
+      in: query
+      required: true
+      description: "The slot for which a sync committee contribution should be created."
+      schema:
+        $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+    - name: subcommittee_index
+      in: query
+      description: "the subcommittee index for which to produce the contribution."
+      required: true
+      schema:
+        $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+    - name: beacon_block_root
+      in: query
+      description: "the block root for which to produce the contribution."
+      required: true
+      schema:
+        $ref: "../../beacon-node-oapi.yaml#/components/schemas/root"
+  responses:
+    "200":
+      description: Success response
+      content:
+        application/json:
+          schema:
+            title: produceSyncCommitteeContributionResponse
+            type: object
+            properties:
+              data:
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Altair.SyncCommitteeContribution'
+    "400":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
+    "500":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
+    "503":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/CurrentlySyncing'

--- a/apis/validator/sync_committee_contribution.yaml
+++ b/apis/validator/sync_committee_contribution.yaml
@@ -23,7 +23,7 @@ get:
       description: "the block root for which to produce the contribution."
       required: true
       schema:
-        $ref: "../../beacon-node-oapi.yaml#/components/schemas/root"
+        $ref: "../../beacon-node-oapi.yaml#/components/schemas/Root"
   responses:
     "200":
       description: Success response

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -130,6 +130,8 @@ paths:
     $ref: "./apis/validator/beacon_committee_subscriptions.yaml"
   /eth/v1/validator/sync_committee_subscriptions:
     $ref: "./apis/validator/sync_committee_subscriptions.yaml"
+  /eth/v1/validator/sync_committee_contribution:
+    $ref: "./apis/validator/sync_committee_contribution.yaml"
 
   /eth/v1/events:
     $ref: "./apis/eventstream/index.yaml"
@@ -211,6 +213,8 @@ components:
       $ref: './types/altair/state.yaml#/Altair/BeaconState'
     Altair.SyncCommitteeSubscription:
       $ref: './types/altair/sync_committee.yaml#/Altair/SyncCommitteeSubscription'
+    Altair.SyncCommitteeContribution:
+      $ref: './types/altair/sync_committee.yaml#/Altair/SyncCommitteeContribution'
 
   parameters:
     StateId:

--- a/types/altair/sync_committee.yaml
+++ b/types/altair/sync_committee.yaml
@@ -28,3 +28,27 @@ Altair:
            - $ref: '../primitive.yaml#/Uint64'
       until_epoch:
         $ref: '../primitive.yaml#/Uint64'
+  SyncCommitteeContribution:
+    type: object
+    properties:
+      slot:
+        allOf:
+          - $ref: "../primitive.yaml#/Uint64"
+          - description: "The slot at which the validator is providing a sync committee contribution."
+      beacon_block_root:
+        allOf:
+          - $ref: '../primitive.yaml#/Root'
+          - description: "Block root for this contribution."
+      subcommittee_index:
+        allOf:
+          - $ref: '../primitive.yaml#/Uint64'
+          - description: 'The index of the subcommittee that the contribution pertains to.'
+      aggregation_bits:
+        allOf:
+          - description: 'A bit is set if a signature from the validator at the corresponding index in the subcommittee is present in the aggregate `signature`.'
+          - $ref: "../primitive.yaml#/Hex"
+          - example: "0x01"
+      signature:
+        allOf:
+          - $ref: '../primitive.yaml#/Signature'
+          - description: 'Signature by the validator(s) over the block root of `slot`'


### PR DESCRIPTION
basically add https://hackmd.io/@QYHAVYiHRg65pdI_CEm7Eg/syncommitteeapi#GET-ethv1validatorsync_committee_contribution1 to standard api spec

re-uses the sync committee contribution description made in #137

in the hackmd there's no mention of a signature, but this object without the signature would be not particularly useful, so i've used the defined sync committee contribution in preference, hopefully that's what's needed.