### PR TITLE
GET `/eth/v1/beacon/states/{state_id}/sync_committees`

### DIFF
--- a/apis/beacon/states/sync_committees.yaml
+++ b/apis/beacon/states/sync_committees.yaml
@@ -1,0 +1,55 @@
+get:
+  operationId: "getEpochSyncCommittees"
+  summary: "Get sync committees for a state."
+  description: "Retrieves the sync committees for the given state."
+  tags:
+    - Beacon
+  parameters:
+    - name: state_id
+      in: path
+      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
+    - name: epoch
+      description: "Fetch sync committees for the given epoch.  If not present then the sync committees for the epoch of the state will be obtained."
+      in: query
+      required: false
+      allowEmptyValue: false
+      schema:
+        allOf:
+          - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+          - example: ""
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            title: GetEpochSyncCommitteesResponse
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.SyncCommittee'
+    "400":
+      description: "Invalid state ID or epoch"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Epoch is outside the sync committee period of the state"
+    "404":
+      description: "State not found"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 404
+            message: "State not found"
+    "500":
+      $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
+

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -61,6 +61,8 @@ paths:
     $ref: "./apis/beacon/states/validator_balances.yaml"
   /eth/v1/beacon/states/{state_id}/committees:
     $ref: "./apis/beacon/states/committee.yaml"
+  /eth/v1/beacon/states/{state_id}/sync_committees:
+    $ref: "./apis/beacon/states/sync_committees.yaml"
   /eth/v1/beacon/headers:
     $ref: "./apis/beacon/blocks/headers.yaml"
   /eth/v1/beacon/headers/{block_id}:
@@ -211,6 +213,8 @@ components:
       $ref: './types/altair/state.yaml#/Altair/BeaconState'
     Altair.SyncCommitteeSubscription:
       $ref: './types/altair/sync_committee.yaml#/Altair/SyncCommitteeSubscription'
+    Altair.SyncCommittee:
+      $ref: './types/altair/sync_committee.yaml#/Altair/SyncCommitteeByValidatorIndices'
 
   parameters:
     StateId:

--- a/types/altair/sync_committee.yaml
+++ b/types/altair/sync_committee.yaml
@@ -28,3 +28,21 @@ Altair:
            - $ref: '../primitive.yaml#/Uint64'
       until_epoch:
         $ref: '../primitive.yaml#/Uint64'
+  ValidatorsByIndex:
+    type: array
+    items:
+      allOf:
+        - $ref: '../primitive.yaml#/Uint64'
+  SyncCommitteeByValidatorIndices:
+    type: object
+    properties:
+      validators:
+        allOf:
+         - $ref: '#/Altair/ValidatorsByIndex'
+         - description: 'all of the validator indices in the current sync committee'
+      validator_aggregates:
+        type: array
+        items:
+          allOf:
+            - $ref: '#/Altair/ValidatorsByIndex'
+            - description: 'Subcommittee slices of the current sync committee'


### PR DESCRIPTION
add definition for sync_committees query of a state

basically adding https://hackmd.io/@QYHAVYiHRg65pdI_CEm7Eg/syncommitteeapi#GET-ethv1beaconstatesstate_idsync_committees to the spec

Names were changed slightly to more closely match the state object structure.