### PR TITLE
add GET `/eth/v2/validator/blocks/{slot}`

### DIFF
--- a/apis/validator/block.v2.yaml
+++ b/apis/validator/block.v2.yaml
@@ -2,12 +2,13 @@ get:
   tags:
     - ValidatorRequiredApi
     - Validator
-  operationId: "produceBlock"
+  operationId: "produceBlockV2"
   summary: "Produce a new block, without signature."
   description: |
     Requests a beacon node to produce a valid block, which can then be signed by a validator.
 
-    __NOTE__: Supports only phase0 blocks.
+    Metadata in the response indicates the type of block produced, and the supported types of block
+    will be added to as forks progress.
   parameters:
     - name: slot
       in: path
@@ -33,11 +34,17 @@ get:
       content:
         application/json:
           schema:
-            title: ProduceBlockResponse
+            title: ProduceBlockV2Response
             type: object
             properties:
+              version:
+                type: string
+                enum: [ phase0, altair ]
+                example: "phase0"
               data:
-                $ref: '../../beacon-node-oapi.yaml#/components/schemas/BeaconBlock'
+                oneOf:
+                 - $ref: '../../beacon-node-oapi.yaml#/components/schemas/BeaconBlock'
+                 - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Altair.BeaconBlock"
     "400":
       description: "Invalid block production request"
       content:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -120,6 +120,8 @@ paths:
     $ref: "./apis/validator/duties/proposer.yaml"
   /eth/v1/validator/blocks/{slot}:
     $ref: "./apis/validator/block.yaml"
+  /eth/v2/validator/blocks/{slot}:
+      $ref: "./apis/validator/block.v2.yaml"
   /eth/v1/validator/attestation_data:
     $ref: "./apis/validator/attestation_data.yaml"
   /eth/v1/validator/aggregate_attestation:
@@ -207,6 +209,8 @@ components:
       $ref: './types/http.yaml#/IndexedErrorMessage'
     Altair.SignedBeaconBlock:
       $ref: './types/altair/block.yaml#/Altair/SignedBeaconBlock'
+    Altair.BeaconBlock:
+      $ref: './types/altair/block.yaml#/Altair/BeaconBlock'
     Altair.BeaconState:
       $ref: './types/altair/state.yaml#/Altair/BeaconState'
     Altair.SyncCommitteeSubscription:


### PR DESCRIPTION
Added a note on the v1 endpoint that it only supports phase0 block production

 Added a note in the description of v2 to indicate the list of supported blocks will change over time as forks progress, hopefully setting the expectation that we're not creating a new api each time a fork happens.