### PR TITLE
POST `/eth/v1/beacon/blocks` for altair

### DIFF
--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -4,14 +4,22 @@ post:
     - ValidatorRequiredApi
   summary: "Publish a signed block."
   operationId: "publishBlock"
-  description: "Instructs the beacon node to broadcast a newly signed beacon block to the beacon network, to be included in the beacon chain. The beacon node is not required to validate the signed `BeaconBlock`, and a successful response (20X) only indicates that the broadcast has been successful. The beacon node is expected to integrate the new block into its state, and therefore validate the block internally, however blocks which fail the validation are still broadcast but a different status code is returned (202)"
+  description: |
+    Instructs the beacon node to broadcast a newly signed beacon block to the beacon network,
+    to be included in the beacon chain. The beacon node is not required to validate the signed
+    `BeaconBlock`, and a successful response (20X) only indicates that the broadcast has been
+    successful. The beacon node is expected to integrate the new block into its state, and
+    therefore validate the block internally, however blocks which fail the validation are still
+    broadcast but a different status code is returned (202)
   requestBody:
     description: "The `SignedBeaconBlock` object composed of `BeaconBlock` object (produced by beacon node) and validator signature."
     required: true
     content:
       application/json:
         schema:
-          $ref: '../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock'
+          oneOf:
+           - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock'
+           - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Altair.SignedBeaconBlock"
   responses:
     "200":
       description: "The block was validated successfully and has been broadcast. It has also been integrated into the beacon node's database."


### PR DESCRIPTION
Given the discussion is leaning towards a POST that takes no indicators for which fork the block is, it would be simple to extend the existing POST to also accept altair blocks.

This PR demonstrates the concept for discussion, as an alternative to #141