### PR TITLE
allow v2 block api to accept content type header

### DIFF
--- a/apis/beacon/blocks/block.v2.yaml
+++ b/apis/beacon/blocks/block.v2.yaml
@@ -1,7 +1,9 @@
 get:
   operationId: getBlockV2
   summary: Get block
-  description: Retrieves block details for given block id.
+  description: |
+    Retrieves block details for given block id.
+    Depending on `Accept` header it can be returned either as json or as bytes serialized by SSZ
   tags:
     - Beacon
   parameters:
@@ -25,6 +27,9 @@ get:
                 oneOf:
                   - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock"
                   - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Altair.SignedBeaconBlock"
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized block bytes. Use Accept header to choose this response type"
     "400":
       description: "The block ID supplied could not be parsed"
       content:


### PR DESCRIPTION
 - blocks will be able to be returned as ssz bytes.