### PR TITLE
add syncnets to identity metadata for altair

### DIFF
--- a/types/p2p.yaml
+++ b/types/p2p.yaml
@@ -34,6 +34,12 @@ MetaData:
         - description: "Bitvector representing the node's persistent attestation subnet subscriptions."
         - $ref: "./primitive.yaml#/Hex"
         - example: "0x0000000000000000"
+    syncnets:
+      allOf:
+        - description: "Bitvector representing the node's sync committee subnet subscriptions."
+        - $ref: "./primitive.yaml#/Hex"
+        - example: "0xF"
+        - required: false
 
 Peer:
   type: object

--- a/types/p2p.yaml
+++ b/types/p2p.yaml
@@ -38,7 +38,7 @@ MetaData:
       allOf:
         - description: "Bitvector representing the node's sync committee subnet subscriptions."
         - $ref: "./primitive.yaml#/Hex"
-        - example: "0xF"
+        - example: "0x0f"
         - required: false
 
 Peer:

--- a/types/p2p.yaml
+++ b/types/p2p.yaml
@@ -36,7 +36,7 @@ MetaData:
         - example: "0x0000000000000000"
     syncnets:
       allOf:
-        - description: "Bitvector representing the node's sync committee subnet subscriptions."
+        - description: "Bitvector representing the node's sync committee subnet subscriptions. This metadata is not present in phase0, but will be present in Altair."
         - $ref: "./primitive.yaml#/Hex"
         - example: "0x0f"
         - required: false


### PR DESCRIPTION
- Added as an optional field, it's only required once we hit altair and this will maintain compatibility with the current interface.