### PR TITLE
remove route on server url

### DIFF
--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -23,7 +23,7 @@ servers:
     variables:
       server_url:
         description: "Beacon node API url"
-        default: "http://public-mainnet-node.ethereum.org/api"
+        default: "http://public-mainnet-node.ethereum.org/"
 
 tags:
   - name: Beacon


### PR DESCRIPTION
The intent was for the provided api's to be from the root path (though not required) and `/api` caused some confusion, so updating route.