### PR TITLE
Clarify spec endpoint values.

### DIFF
--- a/apis/config/spec.yaml
+++ b/apis/config/spec.yaml
@@ -2,8 +2,10 @@ get:
   operationId: getSpec
   summary: Get spec params.
   description: |
-    Retrieve specification configuration used on this node.
-    [Specification params list](https://github.com/ethereum/eth2.0-specs/blob/v1.0.0-rc.0/configs/mainnet/phase0.yaml)
+    Retrieve specification configuration used on this node.  The configuration should include:
+      - Constants for all hard forks known by the beacon node, for example the [phase 0](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#constants) and [altair](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/altair/beacon-chain.md#constants) values
+      - Presets for all hard forks supplied to the beacon node, for example the [phase 0](https://github.com/ethereum/eth2.0-specs/blob/dev/presets/mainnet/phase0.yaml) and [altair](https://github.com/ethereum/eth2.0-specs/blob/dev/presets/mainnet/altair.yaml) values
+      - Configuration for the beacon node, for example the [mainnet](https://github.com/ethereum/eth2.0-specs/blob/dev/configs/mainnet.yaml) values
 
     Values are returned with following format:
       - any value starting with 0x in the spec is returned as a hex string
@@ -22,10 +24,16 @@ get:
             properties:
               data:
                 description: |
-                  Key value mapping of [spec variables](https://github.com/ethereum/eth2.0-specs/blob/v1.0.0-rc.0/configs/mainnet/phase0.yaml).
+                  Key value mapping of all constants, presets and configuration values for all known hard forks
                   Values are returned with following format:
                     - any value starting with 0x in the spec is returned as a hex string
                     - numeric values are returned as a quoted integer
                 type: object
+            example:
+              'DEPOSIT_CONTRACT_ADDRESS': '0x00000000219ab540356cBB839Cbe05303d7705Fa'
+              'DEPOSIT_NETWORK_ID': '1'
+              'DOMAIN_AGGREGATE_AND_PROOF': '0x06000000'
+              'INACTIVITY_PENALTY_QUOTIENT': '67108864'
+              'INACTIVITY_PENALTY_QUOTIENT_ALTAIR': '50331648'
     "500":
       $ref: ../../beacon-node-oapi.yaml#/components/responses/InternalError


### PR DESCRIPTION
Add details about exactly which values should be included in the /config/spec endpoint.  Also add example output showing format of each data type and values that change across forks.