### PR TITLE
Move description of `dependent_root` into new paragraph

### DIFF
--- a/apis/validator/duties/attester.yaml
+++ b/apis/validator/duties/attester.yaml
@@ -18,6 +18,7 @@ post:
 
       - event.block otherwise
 
+    
     The dependent_root value is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)`
     or the genesis block root in the case of underflow."
   parameters:


### PR DESCRIPTION
Currently the description of `dependent_root` is incorrectly placed inside the `event.block otherwise` list element.