### PR TITLE
Move description of `dependent_root` into new paragraph

### DIFF
--- a/apis/validator/duties/proposer.yaml
+++ b/apis/validator/duties/proposer.yaml
@@ -14,6 +14,7 @@ get:
 
      - event.block otherwise
 
+
     The dependent_root value is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch) - 1)`
     or the genesis block root in the case of underflow."
   parameters:


### PR DESCRIPTION
Similarly to #155, the description of `dependent_root` for proposer duties is incorrectly placed.