### PR TITLE
Update description of fork schedule.

### DIFF
--- a/apis/config/fork_schedule.yaml
+++ b/apis/config/fork_schedule.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: getForkSchedule
   summary: Get scheduled upcoming forks.
-  description: Retrieve all scheduled upcoming forks this node is aware of.
+  description: Retrieve all forks, past present and future, of which this node is aware.
   tags:
     - Config
   responses:


### PR DESCRIPTION
This updates the description of the config/fork_schedules endpoint to state that all forks should be returned rather than just the upcoming forks.