### PR TITLE
Make sync committee type conform to spec

### DIFF
--- a/types/altair/sync_committee.yaml
+++ b/types/altair/sync_committee.yaml
@@ -7,15 +7,10 @@ Altair:
         items:
           allOf:
             - $ref: '../primitive.yaml#/Pubkey'
-        minItems: 1024
-        maxItems: 1024
-      pubkey_aggregates:
-        type: array
-        items:
-          allOf:
-            - $ref: '../primitive.yaml#/Pubkey'
-        minItems: 16
-        maxItems: 16
+        minItems: 512
+        maxItems: 512
+      aggregate_pubkey:
+        $ref: '../primitive.yaml#/Pubkey'
   SyncCommitteeSignature:
       type: object
       properties:


### PR DESCRIPTION
The altair response schema for https://ethereum.github.io/eth2.0-APIs/#/Debug/getStateV2 fields `current_sync_committee` and `next_sync_committee` are not in line with the spec. `pubkeys` length is 1024 and `pubkey_aggregates` is an array, whereas https://github.com/ethereum/eth2.0-specs/blob/dev/specs/altair/beacon-chain.md#synccommittee specifies `pubkeys` of length 512 (`SYNC_COMMITTEE_SIZE`) and an `aggregate_pubkey` field which is a single public key.